### PR TITLE
Feature: update helm chart by exposing the metrics port to the internal network

### DIFF
--- a/charts/anchor-platform/sep-service/Chart.yaml
+++ b/charts/anchor-platform/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.88
+version: 0.3.89

--- a/charts/anchor-platform/sep-service/templates/deployment.yaml
+++ b/charts/anchor-platform/sep-service/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
           - name: http
             containerPort: {{ .Values.service.containerPort }}
             protocol: TCP
+          - name: metrics
+            containerPort: 8082
+            protocol: TCP
           {{- if (.Values.deployment).env }}
           env:
 {{ toYaml .Values.deployment.env | indent 12 }}

--- a/charts/anchor-platform/sep-service/values.yaml
+++ b/charts/anchor-platform/sep-service/values.yaml
@@ -33,6 +33,10 @@ deployment:
    envFrom:
    - secretRef:
        name: apsigningseed
+   annotations:
+        prometheus.io/path: /actuator/prometheus
+        prometheus.io/port: "8082"
+        prometheus.io/scrape: "true"
 ingress:
    labels:
      app: appy


### PR DESCRIPTION
### What

* Expose the `8082` metrics port to the internal network.
* Add `deployment.annotations` to the example values.
* Delete duplicate appearance of `ORG_URL` in the example values.

### Why

To improve the helm chart to be closer to a real-world scenario.
