### PR TITLE
Feature: separate observer deployment

### DIFF
--- a/charts/anchor-platform/sep-service/Chart.yaml
+++ b/charts/anchor-platform/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.89
+version: 0.3.91

--- a/charts/anchor-platform/sep-service/templates/deployment.yaml
+++ b/charts/anchor-platform/sep-service/templates/deployment.yaml
@@ -1,3 +1,5 @@
+---
+# SEP Server
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,9 +32,11 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repo }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-          args:
-            - --sep-server
-            - --stellar-observer
+          {{- if (.Values.stellarObserver).enabled }}
+          args: ["--sep-server"]
+          {{- else }}
+          args: ["--sep-server", "--stellar-observer"]
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           startupProbe:
             httpGet:
@@ -106,3 +110,113 @@ spec:
             secretName: {{ $secret.name }}
       {{- end }}
       {{- end }}
+
+{{- $stellarObserverDeployment := ((.Values.stellarObserver).deployment) }}
+{{- if (.Values.stellarObserver).enabled }}
+---
+# Stellar Observer
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.fullName }}-observer
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+    helm.sh/chart: {{ include "common.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.fullName }}-observer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.fullName }}-observer
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if (.Values.deployment).annotations }}
+      annotations:
+        {{- range $key, $value := .Values.deployment.annotations }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      {{- end }}
+    spec:
+      {{- if (.Values.deployment).serviceAccountName }}
+      serviceAccountName: {{ .Values.deployment.serviceAccountName | default "default" }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-observer
+          image: "{{ .Values.image.repo }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          args: ["--stellar-observer"]
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          startupProbe:
+            httpGet:
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            failureThreshold: {{ $stellarObserverDeployment.startupProbeFailureThreshold | default 10 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
+          livenessProbe:
+            httpGet:
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            initialDelaySeconds: {{ $stellarObserverDeployment.initialDelaySeconds | default 30 }}
+            failureThreshold: {{ $stellarObserverDeployment.livenessProbeFailureThreshold | default 2 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            initialDelaySeconds: {{ $stellarObserverDeployment.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
+          volumeMounts:
+            - name: sep-config-volume
+              mountPath: /config
+              readOnly: true
+          {{- if ((.Values.deployment).volumeMounts).configMaps }}
+          {{- range $conf := .Values.deployment.volumeMounts.configMaps }}
+            - mountPath: {{ $conf.mountPath }}
+              name: {{ $conf.name }}-volume
+          {{- end }}
+          {{- end }}
+          {{- if ((.Values.deployment).volumeMounts).secrets }}
+          {{- range $secret := .Values.deployment.volumeMounts.secrets }}
+            - mountPath: {{ $secret.mountPath | default $secret.name }}
+              name: {{ $secret.name }}-volume
+          {{- end }}
+          {{- end }}
+          ports:
+          - name: http
+            containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
+            protocol: TCP
+          {{- if (.Values.deployment).env }}
+          env:
+{{ toYaml .Values.deployment.env | indent 12 }}
+          {{- end }}
+          {{- if (.Values.deployment).envFrom }}
+          envFrom:
+{{ toYaml .Values.deployment.envFrom | indent 12 }}
+          {{- end }}
+          {{- if (.Values.deployment).resources }}
+          resources:
+{{- toYaml .Values.deployment.resources | indent 12 }}
+          {{- end }}     
+      volumes:
+        - name: sep-config-volume
+          configMap:
+            name: {{ .Values.fullName }}
+      {{- if ((.Values.deployment).volumeMounts).configMaps }}
+      {{- range $conf := .Values.deployment.volumeMounts.configMaps }}
+        - name: {{ $conf.name }}-volume
+          configMap:
+            name: {{ $conf.name }}
+      {{- end }}
+      {{- end }}
+      {{- if ((.Values.deployment).volumeMounts).secrets }}
+      {{- range $secret := .Values.deployment.volumeMounts.secrets }}
+        - name: {{ $secret.name }}-volume
+          secret:
+            secretName: {{ $secret.name }}
+      {{- end }}
+      {{- end }}
+
+{{- end }}

--- a/charts/anchor-platform/sep-service/templates/ingress.yaml
+++ b/charts/anchor-platform/sep-service/templates/ingress.yaml
@@ -1,3 +1,5 @@
+---
+# SEP Server
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,7 +37,7 @@ spec:
   - host: {{ tpl .host $ }}
     http:
       paths:
-        - path: {{ .path | quote }}
+        - path: {{ .path }}
           pathType: {{ .pathType| quote }}
           backend:
             service:
@@ -44,3 +46,56 @@ spec:
                 number: {{ tpl .backend.servicePort $ }}
   {{- end }}
   {{- end }}
+
+{{- $root := . }}
+{{- $stellarObserver := (.Values.stellarObserver) }}
+{{- if $stellarObserver.enabled }}
+---
+# Stellar Observer
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.fullName }}-ing-{{ .Values.service.name }}-observer
+  {{- if .Values.ingress.metadata }}
+  {{- range $key, $value := .Values.ingress.metadata }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-ing-{{ .Values.service.name }}-observer
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}  
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ $stellarObserver.ingress.tls.host }}
+    {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+    {{- end }}      
+  {{- end }}
+  {{- if .Values.ingress.rules }}
+  rules:
+  {{- range $stellarObserver.ingress.rules.hosts }}
+  - host: {{ tpl .host $ }}
+    http:
+      paths:
+        - path: {{ .path }}
+          pathType: {{ .pathType | quote }}
+          backend:
+            service:
+              name: {{ $root.Values.fullName }}-svc-{{ $root.Values.service.name }}-observer
+              port:
+                number: {{ $stellarObserver.deployment.port | default 8083 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/anchor-platform/sep-service/templates/service.yaml
+++ b/charts/anchor-platform/sep-service/templates/service.yaml
@@ -1,3 +1,5 @@
+---
+# SEP Server
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +27,35 @@ spec:
     targetPort: {{ .Values.service.targetPort | default 8080 }}  # port number pods listen on
   selector:
     app.kubernetes.io/name: {{ .Values.fullName }}
+
+{{- if (.Values.stellarObserver).enabled }}
+---
+# Stellar Observer
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer
+{{- if .Values.service.annotations }}
+  annotations:
+{{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
+  labels:
+    {{- if .Values.service.labels }}
+    {{- range $key, $value := .Values.service.labels }}
+    {{- end }}
+    {{- end }}
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - protocol: TCP
+    port: {{ ((.Values.stellarObserver).deployment).port | default 8083}}         # port number the service will listen on
+    targetPort: {{ ((.Values.stellarObserver).deployment).port | default 8083 }}  # port number pods listen on
+  selector:
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+{{- end }}

--- a/charts/anchor-platform/sep-service/values.yaml
+++ b/charts/anchor-platform/sep-service/values.yaml
@@ -23,13 +23,6 @@ deployment:
       configMaps:
          - name: assets
            mountPath: assets
-   hosts:
-     - host: "www.stellaranchordemo.com"
-       path: /
-       pathType: Prefix
-       backend:
-         servicePort: "{{ .Values.service.containerPort }}"
-         serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
    envFrom:
    - secretRef:
        name: apsigningseed
@@ -61,8 +54,39 @@ ingress:
           backend:
             servicePort: "{{ .Values.service.containerPort }}"
             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
+#
+# If you want to have a dedicated stellar-observer service, you need to
+# uncomment the `stellarObserver` section below.
+#
+# Attention! If you use the stellar observer as a separate service – by setting
+# `stellarObserver.enabled` flag to `true` – you must use a shared database that
+# will be accessible by both deployments (sep-server and stellar-observer).
+# In-memory databases won't work.
+# stellarObserver:
+#    # This will enable the stellar-observer service as a separate deployment:
+#    enabled: true
+#    # The stellarObserver.deployment section is optional, the templates have
+#    # default values.
+#    deployment:
+#       port: 8083
+#       probePath: "/health"
+#       probePeriodSeconds: 15
+#       initialDelaySeconds: 60
+#       startupProbeFailureThreshold: 10
+#       livenessProbeFailureThreshold: 2
+#    ingress:
+#       tls:
+#          host: "observer.your_anchor_domain.com"    # Replace this with a valid host name
+#       rules:
+#          hosts:
+#          - host: "observer.your_anchor_domain.com"  # Replace this with a valid host name
+#            path: /
+#            pathType: Prefix
+#
 stellar:
    toml:
+      #accounts: ['"GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"'] 
+      signing_key: "GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"
       documentation:
          ORG_NAME: "your_org"
          ORG_URL: "https:/your_org.org"
@@ -74,7 +98,8 @@ stellar:
          settings: data-spring-jdbc-sqlite
 #         settings: data-spring-jdbc-aws-aurora-postgres
 #   data_spring_jdbc_aws_aurora_postgres:
-#      spring.jpa.generate-ddl: true
+#      spring.jpa.generate-ddl: false
+#      spring.jpa.hibernate.ddl-auto: none
 #      spring.jpa.database: POSTGRESQL
 #      spring.jpa.show-sql: false
 #      spring.datasource.driver-class-name: org.postgresql.Driver
@@ -84,6 +109,11 @@ stellar:
 #      spring.datasource.hikari.max-lifetime: 840000    # 14 minutes because IAM tokens are valid for 15min
 #      spring.mvc.converters.preferred-json-mapper: gson
 #      spring.liquibase.change-log: classpath:/db/changelog/db.changelog-master.yaml
+#      spring.flyway.user: ${FLYWAY_USER}
+#      spring.flyway.password: ${FLYWAY_PASSWORD} # can use a token value if authenticating via IAM
+#      spring.flyway.url: jdbc:postgresql://database-aurora.region.rds.amazonaws.com:port/instance
+#      spring.flyway.locations: classpath:/db/migration
+#      spring.flyway.enabled: false
    data_spring_jdbc_sqlite:
       spring.jpa.database-platform: org.stellar.anchor.platform.sqlite.SQLiteDialect
       spring.jpa.hibernate.ddl-auto: update
@@ -94,6 +124,10 @@ stellar:
       spring.datasource.username: ${SQLITE_USERNAME}
       spring.datasource.password: ${SQLITE_PASSWORD}
       spring.mvc.converters.preferred-json-mapper: gson
+      spring.flyway.user: ${SQLITE_USERNAME}
+      spring.flyway.password: ${SQLITE_USERNAME}
+      spring.flyway.url: jdbc:sqlite:anchor-proxy.db
+      spring.flyway.locations: classpath:/db/migration
       spring.flyway.enabled: false
    app_config:
       app:
@@ -113,13 +147,16 @@ stellar:
         signingSeed: ${SEP10_SIGNING_SEED}
         requireKnownOmnibusAccount: false
         omnibusAccountList:
-          # - GC5KRPVW4TFA6ORIGTOFM3DEG6DSLACRXGDN3LNCAI7IPAGIWMVXUHVS
+#        omnibusAccountList: |
+#          GAB24L6CPBKSMQOBXJ5PRA6I66X4TGZHPAEI2CMPNLC6I2WX646OYCAV,
+#          GAB24L6CPBKSMQOBXJ5PRA6I66X4TGZHPAEI2CMPNLC6I2WX646OYCAA
       sep12:
         enabled: true
         customerIntegrationEndpoint: https://anchor-reference-server-dev.stellar.org
       sep31:
         enabled: true
         feeIntegrationEndPoint: https://anchor-reference-server-dev.stellar.org
+        # uniqueAddressIntegrationEndPoint: https://anchor-reference-server-dev.stellar.org
       sep38:
         enabled: true
         quoteIntegrationEndPoint: https://anchor-reference-server-dev.stellar.org


### PR DESCRIPTION
### What

Add an option to make the Stellar observer into a separate deployment service.

### Why

Because it's recommended to use it as a separate service.
Same as https://github.com/stellar/java-stellar-anchor-sdk/pull/613.