### PR TITLE
Improve horizon chart values.yaml

### DIFF
--- a/charts/horizon/README.md
+++ b/charts/horizon/README.md
@@ -1,6 +1,9 @@
 # Stellar Horizon Helm Chart
 
-This chart will deploy stellar-horizon. By default it will be connected to the TESTNET network
+Please note that this chart is not complete yet and should not be used for production deployments.
+
+The chart can deploy ingesting horizon pod and, optionally, dedicated non-ingesting pod(s).
+By default horizon will be connected to the TESTNET network.
 
 ## Usage
 
@@ -12,7 +15,7 @@ Add SDF helm repo to your system:
 ```
 helm repo add stellar https://helm.stellar.org/charts
 ```
-For example to render manifests you can use the followign command:
+For example to render manifests you can use the following command:
 ```
 helm install myhorizon stellar/horizon --set "ingest.existingSecret=horizon-db-secret"
 ```

--- a/charts/horizon/templates/horizon-web-deployment.yaml
+++ b/charts/horizon/templates/horizon-web-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
       - name: horizon
-        image: image: {{ include "common.horizonImage" . | quote }}
+        image: {{ include "common.horizonImage" . | quote }}
         {{- if (.Values.web).cliArgs }}
         args:
           {{- range $flag := .Values.web.cliArgs }}

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -77,6 +77,11 @@ ingest:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
+  ## List of annotations to add to the StatefulSet
+  # annotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "6000"
+
   persistence:
     enabled: false
     storageClass: default
@@ -92,7 +97,14 @@ ingest:
   #    memory: 2Gi
 
   coreExporter:
+    ## Common prometheus config examples do not allow it to scrape 2 ports
+    ## If you'd like to scrape both horizon and core metrics example
+    ## workarounds can be found here:
+    ##   https://github.com/prometheus/prometheus/issues/3756#issuecomment-362266296
+    ##   https://github.com/prometheus/prometheus/issues/3756#issuecomment-874043080
+    ## If you'd like to have prometheus
     enabled: true
+
     ## See global.image.coreExporter for image settings
 
     ## Uncomment to set resource limits
@@ -127,6 +139,11 @@ web:
 
   ## Uncomment to use custom service account
   # serviceAccountName: default
+
+  ## List of annotations to add to the StatefulSet
+  # annotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "6000"
 
   ## Uncomment to set resource limits
   #resources:


### PR DESCRIPTION
### What

The default values.yaml file did not contain example annotations. This PR fixes that

### Why

This will make it easier to deploy the chart and see what values are supported