### PR TITLE
horizon: add arbitrary label support

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: horizon
 description: This chart will deploy Stellar Horizon API server
-version: 0.0.1
+version: 0.0.2
 appVersion: "2.22.1"
 description: Stellar Horizon Helm Chart
 maintainers: 

--- a/charts/horizon/templates/_helpers.tpl
+++ b/charts/horizon/templates/_helpers.tpl
@@ -28,7 +28,7 @@
 {{- template "core.testnetConfig" }}
 {{- else if eq .Values.global.network "pubnet" -}}
 {{- template "core.pubnetConfig" }}
-{{- else if eq .Values.global.network "custom" -}}
+{{- else -}}
 {{- .Values.ingest.coreConfig }}
 {{- end -}}
 {{- end -}}
@@ -38,7 +38,7 @@
 https://history.stellar.org/prd/core-testnet/core_testnet_001,https://history.stellar.org/prd/core-testnet/core_testnet_002,https://history.stellar.org/prd/core-testnet/core_testnet_003
 {{- else if eq .Values.global.network "pubnet" -}}
 https://history.stellar.org/prd/core-live/core_live_001,https://history.stellar.org/prd/core-live/core_live_002,https://history.stellar.org/prd/core-live/core_live_003
-{{- else if eq .Values.global.network "custom" -}}
+{{- else  -}}
 {{- .Values.global.historyArchiveUrls }}
 {{- end -}}
 {{- end -}}
@@ -48,7 +48,7 @@ https://history.stellar.org/prd/core-live/core_live_001,https://history.stellar.
 Test SDF Network ; September 2015
 {{- else if eq .Values.global.network "pubnet" -}}
 Public Global Stellar Network ; September 2015
-{{- else if eq .Values.global.network "custom" -}}
+{{- else -}}
 {{- .Values.global.networkPassphrase }}
 {{- end -}}
 {{- end -}}

--- a/charts/horizon/templates/horizon-ingest-sts.yaml
+++ b/charts/horizon/templates/horizon-ingest-sts.yaml
@@ -23,6 +23,12 @@ spec:
       labels:
         app: {{ template "common.fullname" . }}-ingest
         release: {{ .Release.Name }}
+        horizon_network: {{ .Values.global.network }}
+      {{- if (.Values.ingest).labels }}
+        {{- range $key, $value := .Values.ingest.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
       {{- if (.Values.ingest).annotations }}
       annotations:
         {{- range $key, $value := .Values.ingest.annotations }}

--- a/charts/horizon/templates/horizon-web-deployment.yaml
+++ b/charts/horizon/templates/horizon-web-deployment.yaml
@@ -22,6 +22,12 @@ spec:
       labels:
         app: {{ template "common.fullname" . }}-web
         release: {{ .Release.Name }}
+        horizon_network: {{ .Values.global.network }}
+      {{- if (.Values.web).labels }}
+        {{- range $key, $value := .Values.web.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
       {{- if (.Values.web).annotations }}
       annotations:
         {{- range $key, $value := .Values.web.annotations }}

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -3,14 +3,15 @@ global:
   ## Useful for those using "helm template" to render templates
   # namespace: mynamespace
 
-  ## Stellar network to use. Supported values are "testnet", "pubnet" and "custom"
-  ## When "custom" is used you have to provide extra settings:
+  ## Stellar network to use. When set to "testnet" or "pubnet" default
+  ## recommended config will be used.
+  ## When set to any other value you have to provide extra settings:
   ##   - global.historyArchiveUrls
   ##   - global.networkPassphrase
   ##   - ingest.coreConfig
   network: testnet
 
-  ## Required when global.network is set to "custom"
+  ## Required when global.network is set to non-standard network
   # historyArchiveUrls: "url1,url2,url3"
   # networkPassphrase: "My Stellar Network; June 2020"
 
@@ -67,7 +68,7 @@ ingest:
   ## pre existing secret that contains the DATABASE_URL key with postgres URL
   existingSecret: ""
 
-  ## Required when global.network is set to "custom"
+  ## Required when global.network is set to non-standard value
   ## Also useful if you want to provide non-standard testnet or pubnet config
   # coreConfig:
 
@@ -77,10 +78,13 @@ ingest:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## List of annotations to add to the StatefulSet
+  ## Additional annotations or labels to add the Deployment template
   # annotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "6000"
+  # labels:
+  #   environment: "dev"
+  #   mylabel1: "myvalue1"
 
   persistence:
     enabled: false
@@ -140,10 +144,13 @@ web:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## List of annotations to add to the StatefulSet
+  ## Additional annotations or labels to add the Deployment template
   # annotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "6000"
+  # labels:
+  #   environment: "dev"
+  #   mylabel1: "myvalue1"
 
   ## Uncomment to set resource limits
   #resources:


### PR DESCRIPTION
### What

* add support for setting arbitrary labels to the horizon chart
* add horizon_network label to Deployment and StatefulSet templates
* allow custom network with any name

### Why

Those changes will give us more control over labels