### PR TITLE
Add futurenet config to Core helm chart

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -17,5 +17,13 @@ For example to render manifests you can use the following command:
 helm install mycore stellar/core
 ```
 
+## Example:
+You can deploy futurenet watcher using `futurenet-values.yaml` config file:
+
+```
+helm install mycore stellar/core --values=futurenet-values.yaml
+
+```
+
 ## TODO
 

--- a/charts/core/futurenet-values.yaml
+++ b/charts/core/futurenet-values.yaml
@@ -1,0 +1,146 @@
+global:
+  ## String to use to explicitly set namespace name in manifests.
+  ## Useful for those using "helm template" to render templates
+  # namespace: mynamespace
+
+  ## Stellar network to use. When set to "testnet" or "pubnet" default
+  ## recommended config will be used.
+  ## When set to any other value you have to provide extra settings:
+  ##   - global.historyArchiveUrls
+  ##   - global.networkPassphrase
+  ##   - core.coreConfig
+  network: testnet # XXX currently testnet and pubnet are not supported
+
+  ## Required when global.network is set to non-standard network
+  # historyArchiveUrls: "url1,url2,url3"
+  # networkPassphrase: "My Stellar Network; June 2020"
+
+  ## String to partially override common.fullname template (will maintain the release name)
+  ##
+  # nameOverride:
+
+  ## String to fully override common.fullname template
+  ##
+  # fullnameOverride:
+
+  ## List of pre-existing image Pull Secrets to use
+  # imagePullSecrets:
+  # - imagepullsecret1
+  # - imagepullsecret2
+
+  image:
+    core:
+      registry: docker.io
+      repository: stellar/stellar-core
+      ## Optional tag. Defaults to the appVersion from Chart.yaml
+      # tag: 1.2.3
+
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: Always
+    coreExporter:
+      registry: docker.io
+      repository: stellar/stellar-core-prometheus-exporter
+      tag: latest
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: Always
+
+core:
+  ## See global.image.core for image settings
+
+  ## List of extra CLI arguments to provide to the stellar-core binary
+  extraCliArgs: []
+
+  ## Required when global.network is set to non-standard value
+  ## Also useful if you want to provide non-standard config
+  # coreConfig:
+
+  ## For production use cases we recommend at least 2 replicas
+  replicaCount: 1
+
+  ## Uncomment to use custom service account
+  # serviceAccountName: default
+
+  ## Additional annotations or labels to add the Deployment template
+  # annotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "6000"
+  # labels:
+  #   environment: "dev"
+  #   mylabel1: "myvalue1"
+
+  persistence:
+    enabled: false
+    storageClass: default
+    size: 100G
+
+  ## Uncomment to set resource limits
+  #resources:
+  #  limits:
+  #    cpu: 2
+  #    memory: 4Gi
+  #  requests:
+  #    cpu: 250m
+  #    memory: 2Gi
+
+  coreExporter:
+    ## Common prometheus config examples do not allow it to scrape 2 ports
+    ## If you'd like to scrape both horizon and core metrics example
+    ## workarounds can be found here:
+    ##   https://github.com/prometheus/prometheus/issues/3756#issuecomment-362266296
+    ##   https://github.com/prometheus/prometheus/issues/3756#issuecomment-874043080
+    ## If you'd like to have prometheus
+    enabled: true
+
+    ## See global.image.coreExporter for image settings
+
+    ## Uncomment to set resource limits
+    #resources:
+    #  limits:
+    #    cpu: 250m
+    #    memory: 512Mi
+    #  requests:
+    #    cpu: 50m
+    #    memory: 128Mi
+
+  config:
+    bucketDirPath: "/var/lib/stellar/buckets"
+    database: "sqlite3:///var/lib/stellar/stellar.db"
+    httpPort: 11626
+    publicHttpPort: true
+    commands:
+      - "ll?level=info"
+    networkPassphrase: "Test SDF Future Network ; October 2022"
+    peerPort: 11625
+    unsafeQuorum: true
+    catchupComplete: false
+    catchupRecent: 1024
+    automaticMaintenancePeriod: 360
+    automaticMaintenanceCount: 150
+    runStandalone: false
+    invariantChecks:
+      - ".*"
+    homeDomains:
+    - homeDomain: "futurenet.stellar.org"
+      quality: "LOW"
+    validators:
+      - name: "futurenet_1"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GBRIF2N52GVN3EXBBICD5F4L5VUFXK6S6VOUCF6T2DWPLOLGWEPPYZTF"
+        address: "horizon-devnet-core-001a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+      - name: "futurenet_2"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GAQM2MF22BYOGIF47RZ2523YK7ZL7Z3CIIX6CCPZBWWLE6KJTXMD4SLO"
+        address: "horizon-devnet-core-002a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+      - name: "futurenet_3"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GC2HLBHG4Z7KV73OPKZD6EWXIXM5QOIZVKN5OS4V2HISDOJC3TUORLY4"
+        address: "horizon-devnet-core-003a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"


### PR DESCRIPTION
### What:
Add futurenet config to Core helm chart

### Why:
We need a sample config file in core helm chart for the watcher.