### PR TITLE
Add history proxy support to the core chart

### DIFF
--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -23,6 +23,3 @@
 {{ .Values.global.image.core.registry }}/{{ .Values.global.image.core.repository }}:{{ default .Chart.AppVersion .Values.global.image.core.tag }}
 {{- end -}}
 
-{{- define "core.config" -}}
-{{- default "Please pass core.coreConfig value" .Values.core.coreConfig }}
-{{- end -}}

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -105,10 +105,34 @@ spec:
 {{ toYaml .Values.core.coreExporter.resources | indent 10 }}
         {{- end }}
       {{- end }}
+      {{- if (.Values.core.historyProxy).enabled }}
+      - name: history-proxy
+        image: "{{ .Values.global.image.historyProxy.registry }}/{{ .Values.global.image.historyProxy.repository }}:{{ .Values.global.image.historyProxy.tag }}"
+        imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
+        ports:
+        - containerPort: 80
+          name: http
+        {{- if (.Values.core.historyProxy).resources }}
+        resources:
+{{ toYaml .Values.core.historyProxy.resources | indent 10 }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: nginx-config
+        {{- if .Values.core.persistence.enabled }}
+        - mountPath: /var/lib/stellar
+          name: {{ template "common.fullname" . }}-var-lib-stellar
+        {{- end }}
+      {{- end }}
       volumes:
       - name: core-config
         configMap:
           name: {{ template "common.fullname" . }}
+      {{- if (.Values.core.historyProxy).enabled }}
+      - name: nginx-config
+        configMap:
+          name: {{ template "common.fullname" . }}-nginx
+      {{- end }}
   {{- if .Values.core.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -107,7 +107,7 @@ spec:
       {{- end }}
       {{- if (.Values.core.historyProxy).enabled }}
       - name: history-proxy
-        image: "{{ .Values.global.image.historyProxy.registry }}/{{ .Values.global.image.historyProxy.repository }}:{{ .Values.global.image.historyProxy.tag }}"
+        image: "{{ .Values.global.image.nginx.registry }}/{{ .Values.global.image.nginx.repository }}:{{ .Values.global.image.nginx.tag }}"
         imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
         ports:
         - containerPort: 80

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -108,7 +108,7 @@ spec:
       {{- if (.Values.core.historyProxy).enabled }}
       - name: history-proxy
         image: "{{ .Values.global.image.nginx.registry }}/{{ .Values.global.image.nginx.repository }}:{{ .Values.global.image.nginx.tag }}"
-        imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
+        imagePullPolicy: {{ .Values.global.image.nginx.pullPolicy }}
         ports:
         - containerPort: 80
           name: http

--- a/charts/core/templates/history-proxy.yaml
+++ b/charts/core/templates/history-proxy.yaml
@@ -18,9 +18,9 @@ data:
       listen 80;
       server_name _;
       {{- if (.Values.core.historyProxy).localPath }}
-      root {{ .Values.core.historyProxy.localPath }}
+      root {{ .Values.core.historyProxy.localPath }};
       {{- else -}}
-      root /var/lib/stellar/local_archive
+      root /var/lib/stellar/local_archive;
       {{- end }}
 
       location / {

--- a/charts/core/templates/history-proxy.yaml
+++ b/charts/core/templates/history-proxy.yaml
@@ -1,0 +1,85 @@
+{{- if and (.Values.core.historyProxy.enabled) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.fullname" . }}-nginx
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  default.conf: |
+    server {
+      listen 80;
+      server_name _;
+      {{- if (.Values.core.historyProxy).localPath }}
+      root {{ .Values.core.historyProxy.localPath }}
+      {{- else -}}
+      root /var/lib/stellar/local_archive
+      {{- end }}
+
+      location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to a 404
+        try_files $uri $uri/ =404;
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.fullname" . }}-history
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}-history
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+  selector:
+    app: {{ template "common.fullname" . }}
+{{- if and (.Values.core.historyProxy.ingress.enabled) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "common.fullname" . }}-history
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- if (.Values.core.historyProxy.ingress).annotations }}
+  annotations:
+    {{- range $key, $value := .Values.core.historyProxy.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  tls:
+  - secretName: {{ template "common.fullname" . }}-history-cert
+    hosts:
+    - {{ .Values.core.historyProxy.ingress.host }}
+  rules:
+  - host: {{ .Values.core.historyProxy.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "common.fullname" . }}-history
+            port:
+              number: 80
+{{- end }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -52,7 +52,7 @@ global:
     nginx:
       registry: docker.io
       repository: nginx
-      tag: 1.17
+      tag: 1.23
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -11,8 +11,6 @@ global:
   ##   - core.coreConfig
   network: testnet # XXX currently testnet and pubnet are not supported
 
-  ## Required when global.network is set to non-standard network
-  # historyArchiveUrls: "url1,url2,url3"
   # networkPassphrase: "My Stellar Network; June 2020"
 
   ## String to partially override common.fullname template (will maintain the release name)
@@ -50,6 +48,16 @@ global:
       ##
       pullPolicy: Always
 
+    historyProxy:
+      registry: docker.io
+      repository: nginx
+      tag: 1.17
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: Always
+
 core:
   ## See global.image.core for image settings
 
@@ -78,6 +86,33 @@ core:
     enabled: false
     storageClass: default
     size: 100G
+
+  ## Validators need to publish history archives. historyProxy section
+  # will make the chart deplo reverse proxy nginx container
+  historyProxy:
+    enabled: false
+
+    ## Path to serve over http
+    # localPath: /var/lib/stellar/local_archive
+    ## Uncomment to set resource limits
+    #resources:
+    #  limits:
+    #    cpu: 250m
+    #    memory: 512Mi
+    #  requests:
+    #    cpu: 50m
+    #    memory: 50Mi
+
+    ingress:
+      enabled: false
+      host: history-proxy.example.com
+      ## Extra annotations to add to the Ingress object
+      #annotations:
+      #  kubernetes.io/ingress.class: "public"
+      #  cert-manager.io/cluster-issuer: "default"
+      ## Extra labels to add to the Ingress object
+      #labels:
+      #  mylabel: myvalue
 
   ## Uncomment to set resource limits
   #resources:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -48,7 +48,8 @@ global:
       ##
       pullPolicy: Always
 
-    historyProxy:
+    ## We use nginx for the history proxy service
+    nginx:
       registry: docker.io
       repository: nginx
       tag: 1.17


### PR DESCRIPTION
### What

Add history proxy support to the core chart

### Why

This is required for validator nodes