### PR TITLE
soroban-rpc: remove dependency on Horizon

### DIFF
--- a/charts/soroban-rpc/templates/_helpers.tpl
+++ b/charts/soroban-rpc/templates/_helpers.tpl
@@ -30,12 +30,3 @@
 {{- printf "http://%s-core:%s" .Release.Name "11626" -}}
 {{- end -}}
 {{- end -}}
-
-
-{{- define "common.horizonUrl" -}}
-{{- if (.Values.sorobanRpc).horizonUrl }}
-{{- .Values.sorobanRpc.horizonUrl }}
-{{- else -}}
-{{- printf "http://%s-horizon-ingest:%s" .Release.Name "80" -}}
-{{- end -}}
-{{- end -}}

--- a/charts/soroban-rpc/templates/soroban-rpc-deployment.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - /bin/bash
         - -c
         # sleep command in the following command is temporary arrangement since soroban rpc needs everything in place. 
-        - sleep 10 && /usr/bin/stellar-soroban-rpc --endpoint=0.0.0.0:{{.Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}  --horizon-url={{ include "common.horizonUrl" .}}  --log-level={{.Values.sorobanRpc.logLevel | default  "info" | quote}} --stellar-core-url={{ include "common.stellarCoreUrl" .}} --network-passphrase={{.Values.sorobanRpc.networkPassphrase | default "Test SDF Future Network ; October 2022" | quote}} --tx-concurrency={{.Values.sorobanRpc.txConcurrency | default 2 }} --tx-queue={{.Values.sorobanRpc.txQueue | default 10 }}
+        - sleep 10 && /usr/bin/stellar-soroban-rpc --endpoint=0.0.0.0:{{.Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}  --log-level={{.Values.sorobanRpc.logLevel | default  "info" | quote}} --stellar-core-url={{ include "common.stellarCoreUrl" .}} --network-passphrase={{.Values.sorobanRpc.networkPassphrase | default "Test SDF Future Network ; October 2022" | quote}}
         imagePullPolicy: {{ .Values.global.image.sorobanRpc.pullPolicy }}
         ports:
         - containerPort: {{ .Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -42,10 +42,6 @@ sorobanRpc:
         kubernetes.io/ingress.class: "public"
         cert-manager.io/cluster-issuer: "default"
 
-  # horizonUrl for stellar-soroban-rpc to connect to horizon.
-  # sorobanRpc.horizonUrl value defaults to the horizon service in the namespace.
-  # horizonUrl: "https://horizon-futurenet.stellar.org"
-
   # stellarCoreUrl for stellar-soroban-rpc to connect to stellar-core watcher node.
   # sorobanRpc.stellarCoreUrl value defaults to the core watcher service.
   # stellarCoreUrl: "http://localhost:11626"


### PR DESCRIPTION
soroban-rpc no longer depends on Horizon and thus we shouldn't be passing a horizon URL to soroban-rpc (thus `--horizon-url=` is no longer supported. This fixes part of https://github.com/stellar/soroban-tools/issues/409)

Also, soroban-rpc no longer uses a submission queue for sending transactions (thus, `--tx-queue=` and `--tx-concurrency=` are no longer supported)

I am not sure when would it be safe to merge this though, since these changes were just recentely merged in the `main` branch of https://github.com/stellar/soroban-tools and this chart seems to depend on `satyamz/soroban-rpc` which I guess @satyamz should build and push.