### PR TITLE
Refactor soroban-rpc chart

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.1.0
+version: 0.1.0-alpha.1
 appVersion: "0.8.0"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:

--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,15 +1,10 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.0.2
-appVersion: "0.0.1"
+version: 0.1.0
+appVersion: "0.8.0"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:
   - name: Stellar Development Foundation
 sources:
-  - https://github.com/stellar/go
+  - https://github.com/stellar/soroban-tools
   - https://github.com/stellar/helm-charts
-dependencies:
-  - name: core
-    repository: "https://helm.stellar.org/charts"
-    version: 0.0.1
-    condition: core.enabled

--- a/charts/soroban-rpc/README.md
+++ b/charts/soroban-rpc/README.md
@@ -10,7 +10,7 @@ Default parameters should be fine for dev environments.
 
 Add SDF helm repo to your system:
 ```
-helm repo add stellar https://helm.stellar.org/charts
+helm repo add stellar https://helm.stellar.org/charts && helm repo update
 ```
 For example to render manifests you can use the following command:
 ```

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -13,6 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   soroban-rpc.cfg: |
+    CAPTIVE_CORE_CONFIG_PATH="/config/stellar-captive-core.cfg"
+    CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar/captive-core"
+    CAPTIVE_CORE_USE_DB=true
+    STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
     ENDPOINT={{ .Values.sorobanRpc.sorobanRpcConfig.endpoint | default "0.0.0.0:8000" | quote }}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).friendbotUrl -}}
     FRIENDBOT_URL={{ .Values.sorobanRpc.sorobanRpcConfig.friendbotUrl | quote }}
@@ -22,18 +26,6 @@ data:
     {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCoreUrl -}}
     STELLAR_CORE_URL={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCoreUrl | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreConfigPath -}}
-    CAPTIVE_CORE_CONFIG_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreConfigPath | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreStoragePath -}}
-    CAPTIVE_CORE_STORAGE_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreStoragePath | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreUseDb -}}
-    CAPTIVE_CORE_USE_DB={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreUseDb }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCoreBinaryPath -}}
-    STELLAR_CORE_BINARY_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCoreBinaryPath | quote }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).historyArchiveUrls -}}
     HISTORY_ARCHIVE_URLS={{ .Values.sorobanRpc.sorobanRpcConfig.historyArchiveUrls | quote }}
@@ -54,11 +46,11 @@ data:
     {{ if (.Values.sorobanRpc.coreConfig).database -}}
     DATABASE={{ (.Values.sorobanRpc.coreConfig).database | quote }}
     {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).experimentalBucketlistDb -}}
-    EXPERIMENTAL_BUCKETLIST_DB={{ (.Values.sorobanRpc.coreConfig).experimentalBucketlistDb }}
+    {{ if (.Values.sorobanRpc.coreConfig).bucketlistDb -}}
+    EXPERIMENTAL_BUCKETLIST_DB={{ (.Values.sorobanRpc.coreConfig).bucketlistDb }}
     {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).experimentalBucketlistDbIndexPageSizeExponent -}}
-    EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).experimentalBucketlistDbIndexPageSizeExponent }}
+    {{ if (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent -}}
+    EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).httpPort -}}
     HTTP_PORT={{ .Values.sorobanRpc.coreConfig.httpPort }}

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -17,46 +17,33 @@ data:
     CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar/captive-core"
     CAPTIVE_CORE_USE_DB=true
     STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
-    ENDPOINT={{ .Values.sorobanRpc.sorobanRpcConfig.endpoint | default "0.0.0.0:8000" | quote }}
+    ENDPOINT="0.0.0.0:8000"
+    ADMIN_ENDPOINT="0.0.0.0:6061"
+    DB_PATH="/var/lib/stellar/soroban-rpc-db.sqlite"
+    STELLAR_CAPTIVE_CORE_HTTP_PORT=11626
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).friendbotUrl -}}
     FRIENDBOT_URL={{ .Values.sorobanRpc.sorobanRpcConfig.friendbotUrl | quote }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).networkPassphrase -}}
     NETWORK_PASSPHRASE={{ .Values.sorobanRpc.sorobanRpcConfig.networkPassphrase | quote }}
     {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCoreUrl -}}
-    STELLAR_CORE_URL={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCoreUrl | quote }}
-    {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).historyArchiveUrls -}}
     HISTORY_ARCHIVE_URLS={{ .Values.sorobanRpc.sorobanRpcConfig.historyArchiveUrls | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).dbPath -}}
-    DB_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.dbPath | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCaptiveCorePort -}}
-    STELLAR_CAPTIVE_CORE_HTTP_PORT={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCaptiveCorePort }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).checkpointFrequence -}}
     CHECKPOINT_FREQUENCY={{ .Values.sorobanRpc.sorobanRpcConfig.checkpointFrequence }}
     {{ end }}
   stellar-captive-core.cfg: |
+    DATABASE="sqlite3:///var/lib/stellar/stellar-captive-core.db"
+    HTTP_PORT=11626
+    PUBLIC_HTTP_PORT=true
+    PEER_PORT=11625
+    EXPERIMENTAL_BUCKETLIST_DB=true
     {{ if (.Values.sorobanRpc.coreConfig).bucketDirPath -}}
     BUCKET_DIR_PATH={{ .Values.sorobanRpc.coreConfig.bucketDirPath |quote -}}
     {{ end }}
-    {{ if (.Values.sorobanRpc.coreConfig).database -}}
-    DATABASE={{ (.Values.sorobanRpc.coreConfig).database | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).bucketlistDb -}}
-    EXPERIMENTAL_BUCKETLIST_DB={{ (.Values.sorobanRpc.coreConfig).bucketlistDb }}
-    {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent -}}
     EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).httpPort -}}
-    HTTP_PORT={{ .Values.sorobanRpc.coreConfig.httpPort }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).publicHttpPort -}}
-    PUBLIC_HTTP_PORT={{ .Values.sorobanRpc.coreConfig.publicHttpPort }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).httpMaxClient -}}
     HTTP_MAX_CLIENT={{ .Values.sorobanRpc.coreConfig.httpMaxClient }}
@@ -69,9 +56,6 @@ data:
     {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).networkPassphrase  -}}
     NETWORK_PASSPHRASE={{ .Values.sorobanRpc.coreConfig.networkPassphrase | quote }}
-    {{ end -}}
-    {{ if (.Values.sorobanRpc.coreConfig).peerPort -}}
-    PEER_PORT={{ .Values.sorobanRpc.coreConfig.peerPort }}
     {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).targetPeerConnections -}}
     TARGET_PEER_CONNECTIONS={{ .Values.sorobanRpc.coreConfig.targetPeerConnections }}

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -1,0 +1,212 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  soroban-rpc.cfg: |
+    ENDPOINT={{ .Values.sorobanRpc.sorobanRpcConfig.endpoint | default "0.0.0.0:8000" | quote }}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).friendbotUrl -}}
+    FRIENDBOT_URL={{ .Values.sorobanRpc.sorobanRpcConfig.friendbotUrl | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).networkPassphrase -}}
+    NETWORK_PASSPHRASE={{ .Values.sorobanRpc.sorobanRpcConfig.networkPassphrase | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCoreUrl -}}
+    STELLAR_CORE_URL={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCoreUrl | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreConfigPath -}}
+    CAPTIVE_CORE_CONFIG_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreConfigPath | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreStoragePath -}}
+    CAPTIVE_CORE_STORAGE_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreStoragePath | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).captiveCoreUseDb -}}
+    CAPTIVE_CORE_USE_DB={{ .Values.sorobanRpc.sorobanRpcConfig.captiveCoreUseDb }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCoreBinaryPath -}}
+    STELLAR_CORE_BINARY_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCoreBinaryPath | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).historyArchiveUrls -}}
+    HISTORY_ARCHIVE_URLS={{ .Values.sorobanRpc.sorobanRpcConfig.historyArchiveUrls | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).dbPath -}}
+    DB_PATH={{ .Values.sorobanRpc.sorobanRpcConfig.dbPath | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).stellarCaptiveCorePort -}}
+    STELLAR_CAPTIVE_CORE_HTTP_PORT={{ .Values.sorobanRpc.sorobanRpcConfig.stellarCaptiveCorePort }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.sorobanRpcConfig).checkpointFrequence -}}
+    CHECKPOINT_FREQUENCY={{ .Values.sorobanRpc.sorobanRpcConfig.checkpointFrequence }}
+    {{ end }}
+  stellar-captive-core.cfg: |
+    {{ if (.Values.sorobanRpc.coreConfig).bucketDirPath -}}
+    BUCKET_DIR_PATH={{ .Values.sorobanRpc.coreConfig.bucketDirPath |quote -}}
+    {{ end }}
+    {{ if (.Values.sorobanRpc.coreConfig).database -}}
+    DATABASE={{ (.Values.sorobanRpc.coreConfig).database | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).experimentalBucketlistDb -}}
+    EXPERIMENTAL_BUCKETLIST_DB={{ (.Values.sorobanRpc.coreConfig).experimentalBucketlistDb }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).experimentalBucketlistDbIndexPageSizeExponent -}}
+    EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).experimentalBucketlistDbIndexPageSizeExponent }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).httpPort -}}
+    HTTP_PORT={{ .Values.sorobanRpc.coreConfig.httpPort }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).publicHttpPort -}}
+    PUBLIC_HTTP_PORT={{ .Values.sorobanRpc.coreConfig.publicHttpPort }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).httpMaxClient -}}
+    HTTP_MAX_CLIENT={{ .Values.sorobanRpc.coreConfig.httpMaxClient }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).commands  -}}
+    COMMANDS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.commands }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).nodeNames  -}}
+    NODE_NAMES=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.nodeNames }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).networkPassphrase  -}}
+    NETWORK_PASSPHRASE={{ .Values.sorobanRpc.coreConfig.networkPassphrase | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerPort -}}
+    PEER_PORT={{ .Values.sorobanRpc.coreConfig.peerPort }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).targetPeerConnections -}}
+    TARGET_PEER_CONNECTIONS={{ .Values.sorobanRpc.coreConfig.targetPeerConnections }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).maxAdditionalPeerConnections -}}
+    MAX_ADDITIONAL_PEER_CONNECTIONS={{ .Values.sorobanRpc.coreConfig.maxAdditionalPeerConnections }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).maxPendingConnections -}}
+    MAX_PENDING_CONNECTIONS={{ .Values.sorobanRpc.coreConfig.maxPendingConnections }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerAuthenticationTimeout -}}
+    PEER_AUTHENTICATION_TIMEOUT={{ .Values.sorobanRpc.coreConfig.peerAuthenticationTimeout }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerStragglerTimeout -}}
+    PEER_STRAGGLER_TIMEOUT={{ .Values.sorobanRpc.coreConfig.peerStragglerTimeout }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerTimeout -}}
+    PEER_TIMEOUT={{ .Values.sorobanRpc.coreConfig.peerTimeout }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).preferredPeers  -}}
+    PREFERRED_PEERS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.preferredPeers }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).preferredPeerKeys  -}}
+    PREFERRED_PEER_KEYS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.preferredPeerKeys}}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).preferredPeersOnly -}}
+    PREFERRED_PEERS_ONLY={{ .Values.sorobanRpc.coreConfig.preferredPeersOnly | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).minimumIdlePercent -}}
+    MINIMUM_IDLE_PERCENT={{ .Values.sorobanRpc.coreConfig.minimumIdlePercent }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).knownPeers  -}}
+    KNOWN_PEERS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.knownPeers }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).knownCursors  -}}
+    KNOWN_CURSORS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.knownCursors }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).nodeSeed  -}}
+    NODE_SEED={{ .Values.sorobanRpc.coreConfig.nodeSeed | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).nodeIsValidator -}}
+    NODE_IS_VALIDATOR={{ .Values.sorobanRpc.coreConfig.nodeIsValidator }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).failureSafety -}}
+    FAILURE_SAFETY={{ .Values.sorobanRpc.coreConfig.failureSafety | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).unsafeQuorum -}}
+    UNSAFE_QUORUM={{ .Values.sorobanRpc.coreConfig.unsafeQuorum }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).catchupComplete -}}
+    CATCHUP_COMPLETE={{ .Values.sorobanRpc.coreConfig.catchupComplete }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).catchupRecent -}}
+    CATCHUP_RECENT={{ .Values.sorobanRpc.coreConfig.catchupRecent }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).haltOnInternalTransactionError -}}
+    HALT_ON_INTERNAL_TRANSACTION_ERROR={{ .Values.sorobanRpc.coreConfig.haltOnInternalTransactionError | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerReadingCapacity -}}
+    PEER_READING_CAPACITY={{ .Values.sorobanRpc.coreConfig.peerReadingCapacity }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).peerFloodReadingCapacity -}}
+    PEER_FLOOD_READING_CAPACITY={{ .Values.sorobanRpc.coreConfig.peerFloodReadingCapacity }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).flowControlSendMoreBatchSize -}}
+    FLOW_CONTROL_SEND_MORE_BATCH_SIZE={{ .Values.sorobanRpc.coreConfig.flowControlSendMoreBatchSize }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).maxConcurrentSubprocesses -}}
+    MAX_CONCURRENT_SUBPROCESSES={{ .Values.sorobanRpc.coreConfig.maxConcurrentSubprocesses }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).automaticMaintenancePeriod -}}
+    AUTOMATIC_MAINTENANCE_PERIOD={{ .Values.sorobanRpc.coreConfig.automaticMaintenancePeriod }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).automaticMaintenanceCount -}}
+    AUTOMATIC_MAINTENANCE_COUNT={{ .Values.sorobanRpc.coreConfig.automaticMaintenanceCount }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).runStandalone -}}
+    RUN_STANDALONE={{ .Values.sorobanRpc.coreConfig.runStandalone | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).invariantChecks  -}}
+    INVARIANT_CHECKS=["{{- join "\",\"" .Values.sorobanRpc.coreConfig.invariantChecks }}"]
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).manualClose -}}
+    MANUAL_CLOSE={{ .Values.sorobanRpc.coreConfig.manualClose | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).artificiallyGenerateLoadForTesting -}}
+    ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING={{ .Values.sorobanRpc.coreConfig.artificiallyGenerateLoadForTesting | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).artificiallyAccelerateTimeForTesting -}}
+    ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING={{ .Values.sorobanRpc.coreConfig.artificiallyAccelerateTimeForTesting | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).artificiallySetCloseTimeForTesting -}}
+    ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING={{ .Values.sorobanRpc.coreConfig.artificiallySetCloseTimeForTesting | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).allowLocalhostForTesting -}}
+    ALLOW_LOCALHOST_FOR_TESTING={{ .Values.sorobanRpc.coreConfig.allowLocalhostForTesting | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).nodeHomeDomain -}}
+    NODE_HOME_DOMAIN={{ .Values.sorobanRpc.coreConfig.nodeHomeDomain | quote }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).homeDomains -}}
+    {{- range $homeDomain := .Values.sorobanRpc.coreConfig.homeDomains }}
+    [[HOME_DOMAINS]]
+    HOME_DOMAIN={{ get $homeDomain "homeDomain" | quote }}
+    QUALITY={{ get $homeDomain "quality" | quote}}
+    {{- end }}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).validators -}}
+    {{ range $validator := .Values.sorobanRpc.coreConfig.validators -}}
+    [[VALIDATORS]]
+    NAME={{ get $validator "name" | quote }}
+    HOME_DOMAIN={{ get $validator "homeDomain" | quote }}
+    PUBLIC_KEY={{ get $validator "publicKey" | quote }}
+    ADDRESS={{ get $validator "address" | quote }}
+    {{ if get $validator "quality" -}}
+    QUALITY={{ get $validator "quality" | quote }}
+    {{ end -}}
+    {{ if get $validator "history" -}}
+    HISTORY={{ get $validator "history" | quote }}
+    {{ end -}}
+    {{ end -}}
+    {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).historyArchives -}}
+    {{ range $key, $value := .Values.sorobanRpc.coreConfig.historyArchives -}}
+    [HISTORY.{{ $key }}]
+    get={{ get $value "get" | quote }}
+    put={{ get $value "put" | quote }}
+    mkdir={{ get $value "mkdir" | quote }}
+    {{ end -}}
+    {{ end -}}

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -57,8 +57,10 @@ spec:
           mountPath: /var/lib/stellar
         {{- end }}
         ports:
-        - containerPort: {{ .Values.sorobanRpc.port | default 8000 }}
+        - containerPort: 8000
           name: soroban-rpc
+        - containerPort: 6061
+          name: admin-port
         {{if (.Values.sorobanRpc).resources}}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}
@@ -95,8 +97,8 @@ spec:
   type: ClusterIP
   ports:
     - name: soroban-rpc
-      port: {{ .Values.sorobanRpc.port | default 8000 }}
-      targetPort: {{ .Values.sorobanRpc.port | default 8000 }}
+      port: 8000
+      targetPort: 8000
   selector:
     app: {{ template "common.fullname" . }}
 ---
@@ -128,4 +130,4 @@ spec:
           service:
             name: {{ template "common.fullname" . }}
             port:
-              number: {{ .Values.sorobanRpc.port | default 8000 }}
+              number: 8000

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "common.fullname" . }}
   {{- if .Release.Namespace }}
@@ -12,7 +12,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.sorobanRpc.replicaCount }}
+  # Currently Soroban RPC doesn't support HA deployments.
+  # For that reason we hardcode replicas value at 1
+  replicas: 1
+  serviceName: {{ template "common.fullname" . }}
   selector:
     matchLabels:
       app: {{ template "common.fullname" . }}
@@ -43,19 +46,38 @@ spec:
       containers:
       - name: soroban-rpc
         image: {{ include "common.sorobanRpcImage" . | quote }}
-        command:
-        - /bin/bash
-        - -c
-        # sleep command in the following command is temporary arrangement since soroban rpc needs everything in place. 
-        - sleep 10 && /usr/bin/stellar-soroban-rpc --endpoint=0.0.0.0:{{.Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}  --log-level={{.Values.sorobanRpc.logLevel | default  "info" | quote}} --stellar-core-url={{ include "common.stellarCoreUrl" .}} --network-passphrase={{.Values.sorobanRpc.networkPassphrase | default "Test SDF Future Network ; October 2022" | quote}}
+        args: ["--config-path", "/config/soroban-rpc.cfg"]
         imagePullPolicy: {{ .Values.global.image.sorobanRpc.pullPolicy }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config
+          readOnly: true
+        {{- if .Values.sorobanRpc.persistence.enabled }}
+        - name: {{ template "common.fullname" . }}-var-lib-stellar
+          mountPath: /var/lib/stellar
+        {{- end }}
         ports:
-        - containerPort: {{ .Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}
+        - containerPort: {{ .Values.sorobanRpc.port | default 8000 }}
           name: soroban-rpc
         {{if (.Values.sorobanRpc).resources}}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}
         {{- end }}
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ template "common.fullname" . }}
+  {{- if .Values.sorobanRpc.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "common.fullname" . }}-var-lib-stellar
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: {{ .Values.sorobanRpc.persistence.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.sorobanRpc.persistence.size | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -73,8 +95,8 @@ spec:
   type: ClusterIP
   ports:
     - name: soroban-rpc
-      port: {{ .Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}
-      targetPort: {{ .Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}
+      port: {{ .Values.sorobanRpc.port | default 8000 }}
+      targetPort: {{ .Values.sorobanRpc.port | default 8000 }}
   selector:
     app: {{ template "common.fullname" . }}
 ---
@@ -85,9 +107,9 @@ metadata:
   {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
-  {{- if (.Values.sorobanRpc.sorobanRpcConfig.ingress).annotations }}
+  {{- if (.Values.sorobanRpc.ingress).annotations }}
   annotations:
-    {{- range $key, $value := .Values.sorobanRpc.sorobanRpcConfig.ingress.annotations }}
+    {{- range $key, $value := .Values.sorobanRpc.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
@@ -95,9 +117,9 @@ spec:
   tls:
   - secretName: {{ template "common.fullname" . }}-cert
     hosts:
-    - {{ .Values.sorobanRpc.sorobanRpcConfig.ingress.host | quote }}
+    - {{ .Values.sorobanRpc.ingress.host | quote }}
   rules:
-  - host: {{ .Values.sorobanRpc.sorobanRpcConfig.ingress.host | quote }}
+  - host: {{ .Values.sorobanRpc.ingress.host | quote }}
     http:
       paths:
       - path: /
@@ -106,4 +128,4 @@ spec:
           service:
             name: {{ template "common.fullname" . }}
             port:
-              number: {{ .Values.sorobanRpc.sorobanRpcConfig.port | default 8000 }}
+              number: {{ .Values.sorobanRpc.port | default 8000 }}

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -32,32 +32,16 @@ global:
 sorobanRpc:
   ## See global.image.sorobanRpc for image settings
 
-
-  ## This variable allows overrides of default settings. It will be used as a container port
-  ## and port where soroban-rpc server will listen.
-  # port: 8000
-
   ## Soroban-rpc config variables
   sorobanRpcConfig:
-    endopoint: "0.0.0.0:8000"
     friendbotUrl: "https://friendbot-futurenet.stellar.org/"
     networkPassphrase: "Test SDF Future Network ; October 2022"
-    stellarCoreUrl: "http://localhost:11626"
     historyArchiveUrls: "http://history-futurenet.stellar.org"
-    dbPath: "/var/lib/stellar/soroban-rpc-db.sqlite"
-    stellarCaptiveCorePort: 11626
     checkpointFrequence: 64
 
   coreConfig:
     networkPassphrase: "Test SDF Future Network ; October 2022"
-    httpPort: 11626
-    publicHttpPort: true
-    peerPort: 11625
-
-    database: "sqlite3:///var/lib/stellar/stellar-captive-core.db"
-    bucketlistDb: "true"
     bucketlistDbIndexPageSizeExponent: 12
-
     failureSafety: 0
     unsafeQuorum: true
 
@@ -83,9 +67,10 @@ sorobanRpc:
 
   ingress:
     host: example.com
-    annotations:
-      kubernetes.io/ingress.class: "public"
-      cert-manager.io/cluster-issuer: "default"
+    ## Additional annotations to add the Ingress template
+    #annotations:
+    #  kubernetes.io/ingress.class: "public"
+    #  cert-manager.io/cluster-issuer: "default"
 
   ## Whether to provision persistent volume. Recommended for production use cases. Usage of the PV has benefit of avoiding ephemeral storage, which can vary on different infrastructure and potentially be too low for the combined needs of the rpc and captive core processes. Choosing a PV storage class also allows leveraging any IaaS provided volumes with solid read/write performance.
   persistence:
@@ -99,7 +84,7 @@ sorobanRpc:
   ## Additional annotations or labels to add the StatefulSet template
   # annotations:
   #   prometheus.io/scrape: "true"
-  #   prometheus.io/port: "8001"
+  #   prometheus.io/port: "6061"
   # labels:
   #   environment: "dev"
   #   mylabel1: "dev-value"

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -87,7 +87,7 @@ sorobanRpc:
       kubernetes.io/ingress.class: "public"
       cert-manager.io/cluster-issuer: "default"
 
-  ## Whether to provision persistent volume. Recommended for production use cases
+  ## Whether to provision persistent volume. Recommended for production use cases. Usage of the PV has benefit of avoiding ephemeral storage, which can vary on different infrastructure and potentially be too low for the combined needs of the rpc and captive core processes. Choosing a PV storage class also allows leveraging any IaaS provided volumes with solid read/write performance.
   persistence:
     enabled: false
     storageClass: default

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -43,10 +43,6 @@ sorobanRpc:
     friendbotUrl: "https://friendbot-futurenet.stellar.org/"
     networkPassphrase: "Test SDF Future Network ; October 2022"
     stellarCoreUrl: "http://localhost:11626"
-    captiveCoreConfigPath: "/config/stellar-captive-core.cfg"
-    captiveCoreStoragePath: "/var/lib/stellar/captive-core"
-    captiveCoreUseDb: true
-    stellarCoreBinaryPath: "/usr/bin/stellar-core"
     historyArchiveUrls: "http://history-futurenet.stellar.org"
     dbPath: "/var/lib/stellar/soroban-rpc-db.sqlite"
     stellarCaptiveCorePort: 11626
@@ -59,8 +55,8 @@ sorobanRpc:
     peerPort: 11625
 
     database: "sqlite3:///var/lib/stellar/stellar-captive-core.db"
-    experimentalBucketlistDb: "true"
-    experimentalBucketlistDbIndexPageSizeExponent: 12
+    bucketlistDb: "true"
+    bucketlistDbIndexPageSizeExponent: 12
 
     failureSafety: 0
     unsafeQuorum: true

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -19,9 +19,9 @@ global:
   image:
     sorobanRpc:
       registry: docker.io
-      repository: 2opremio/soroban-rpc
+      repository: stellar/soroban-rpc
       ## Optional tag. Defaults to the appVersion from Chart.yaml
-      tag: 6dc54bd
+      # tag: abc123
 
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -32,36 +32,78 @@ global:
 sorobanRpc:
   ## See global.image.sorobanRpc for image settings
 
+
   ## This variable allows overrides of default settings. It will be used as a container port
   ## and port where soroban-rpc server will listen.
+  # port: 8000
+
+  ## Soroban-rpc config variables
   sorobanRpcConfig:
-    port: 8000
-    ingress:
-      host: example.com
-      annotations:
-        kubernetes.io/ingress.class: "public"
-        cert-manager.io/cluster-issuer: "default"
+    endopoint: "0.0.0.0:8000"
+    friendbotUrl: "https://friendbot-futurenet.stellar.org/"
+    networkPassphrase: "Test SDF Future Network ; October 2022"
+    stellarCoreUrl: "http://localhost:11626"
+    captiveCoreConfigPath: "/config/stellar-captive-core.cfg"
+    captiveCoreStoragePath: "/var/lib/stellar/captive-core"
+    captiveCoreUseDb: true
+    stellarCoreBinaryPath: "/usr/bin/stellar-core"
+    historyArchiveUrls: "http://history-futurenet.stellar.org"
+    dbPath: "/var/lib/stellar/soroban-rpc-db.sqlite"
+    stellarCaptiveCorePort: 11626
+    checkpointFrequence: 64
 
-  # stellarCoreUrl for stellar-soroban-rpc to connect to stellar-core watcher node.
-  # sorobanRpc.stellarCoreUrl value defaults to the core watcher service.
-  # stellarCoreUrl: "http://localhost:11626"
+  coreConfig:
+    networkPassphrase: "Test SDF Future Network ; October 2022"
+    httpPort: 11626
+    publicHttpPort: true
+    peerPort: 11625
 
-  # networkPassphrase for stellar-soroban-rpc to connect to network.
-  networkPassphrase: "Test SDF Future Network ; October 2022"
+    database: "sqlite3:///var/lib/stellar/stellar-captive-core.db"
+    experimentalBucketlistDb: "true"
+    experimentalBucketlistDbIndexPageSizeExponent: 12
 
-  # Set logLevel for stellar-soroban-rpc
-  logLevel: "info"
+    failureSafety: 0
+    unsafeQuorum: true
 
-  ## For production use cases we recommend at least 2 replicas
-  replicaCount: 1
+    homeDomains:
+    - homeDomain: "futurenet.stellar.org"
+      quality: "MEDIUM"
+    validators:
+      - name: "sdf_futurenet_1"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GBRIF2N52GVN3EXBBICD5F4L5VUFXK6S6VOUCF6T2DWPLOLGWEPPYZTF"
+        address: "horizon-devnet-core-001a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+      - name: "sdf_futurenet_2"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GAQM2MF22BYOGIF47RZ2523YK7ZL7Z3CIIX6CCPZBWWLE6KJTXMD4SLO"
+        address: "horizon-devnet-core-002a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+      - name: "sdf_futurenet_3"
+        homeDomain: "futurenet.stellar.org"
+        publicKey: "GC2HLBHG4Z7KV73OPKZD6EWXIXM5QOIZVKN5OS4V2HISDOJC3TUORLY4"
+        address: "horizon-devnet-core-003a.dev.stellar002.external.stellar-ops.com"
+        history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+
+  ingress:
+    host: example.com
+    annotations:
+      kubernetes.io/ingress.class: "public"
+      cert-manager.io/cluster-issuer: "default"
+
+  ## Whether to provision persistent volume. Recommended for production use cases
+  persistence:
+    enabled: false
+    storageClass: default
+    size: 100G
 
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## Additional annotations or labels to add the Deployment template
+  ## Additional annotations or labels to add the StatefulSet template
   # annotations:
   #   prometheus.io/scrape: "true"
-  #   prometheus.io/port: "6000"
+  #   prometheus.io/port: "8001"
   # labels:
   #   environment: "dev"
   #   mylabel1: "dev-value"
@@ -75,52 +117,3 @@ sorobanRpc:
   #    cpu: 250m
   #    memory: 2Gi
 
-core:
-  enabled: true
-  global:
-    image:
-      core:
-        registry: docker-registry.services.stellar-ops.com
-        repository: dev/stellar-core
-        tag: 19.6.1-1158.c0ad35aa1.focal-soroban
-  core:
-    persistence:
-      enabled: true
-      storageClass: default
-      size: 100G
-    config:
-      bucketDirPath: "/var/lib/stellar/buckets"
-      database: "sqlite3:///var/lib/stellar/stellar.db"
-      httpPort: 11626
-      publicHttpPort: true
-      commands:
-        - "ll?level=info"
-      networkPassphrase: "Test SDF Future Network ; October 2022"
-      peerPort: 11625
-      unsafeQuorum: true
-      catchupComplete: false
-      catchupRecent: 1024
-      automaticMaintenancePeriod: 360
-      automaticMaintenanceCount: 150
-      runStandalone: false
-      invariantChecks:
-        - ".*"
-      homeDomains:
-      - homeDomain: "futurenet.stellar.org"
-        quality: "LOW"
-      validators:
-        - name: "futurenet_1"
-          homeDomain: "futurenet.stellar.org"
-          publicKey: "GBRIF2N52GVN3EXBBICD5F4L5VUFXK6S6VOUCF6T2DWPLOLGWEPPYZTF"
-          address: "horizon-devnet-core-001a.dev.stellar002.external.stellar-ops.com"
-          history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
-        - name: "futurenet_2"
-          homeDomain: "futurenet.stellar.org"
-          publicKey: "GAQM2MF22BYOGIF47RZ2523YK7ZL7Z3CIIX6CCPZBWWLE6KJTXMD4SLO"
-          address: "horizon-devnet-core-002a.dev.stellar002.external.stellar-ops.com"
-          history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
-        - name: "futurenet_3"
-          homeDomain: "futurenet.stellar.org"
-          publicKey: "GC2HLBHG4Z7KV73OPKZD6EWXIXM5QOIZVKN5OS4V2HISDOJC3TUORLY4"
-          address: "horizon-devnet-core-003a.dev.stellar002.external.stellar-ops.com"
-          history: "curl -sf http://history-futurenet.stellar.org/{0} -o {1}"


### PR DESCRIPTION
### What

This PR refactors the soroban-rpc chart. Summary of changes made:
* updated default docker registry to the official stellar registry
* removed stellar core subchart since we don't use it any more
* moved core settings one level up in the values file
* updated core settings to match latest recommended values
* soroban-rpc now accepts config file. Moved config to ConfigMap
* soroban-rpc doesn't support HA yet, harcoded replicas at 1 to avoid mistakes
* moved from Deployment to StatefulSet. Split templates into multiple files
* added persistence support
* bumped appVersion to latest preview release of soroban

### Why

Soroban-rpc now comes with core bundled and the chart has to be updated to match that.