### PR TITLE
soroban-rpc: disable persistence support

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.1.0-alpha.2
+version: 0.1.0-beta.1
 appVersion: "0.8.0"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -52,7 +52,7 @@ spec:
         - name: config-volume
           mountPath: /config
           readOnly: true
-        {{- if .Values.sorobanRpc.persistence.enabled }}
+        {{- if (.Values.sorobanRpc.persistence).enabled }}
         - name: {{ template "common.fullname" . }}-var-lib-stellar
           mountPath: /var/lib/stellar
         {{- end }}
@@ -69,7 +69,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "common.fullname" . }}
-  {{- if .Values.sorobanRpc.persistence.enabled }}
+  {{- if (.Values.sorobanRpc.persistence).enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "common.fullname" . }}-var-lib-stellar

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -78,6 +78,16 @@ sorobanRpc:
     #annotations:
     #  cert-manager.io/cluster-issuer: "default"
 
+  ## Whether to provision persistent volume(PV). Recommended for production use cases and any deployment that is
+  ## configured to be on the pubnet network. On pubnet network, disk requirements start at 30GB minimum,
+  ## which pushes on the typical upper limit of ephemeral storage provided in cluster containers.
+  ## Choosing a PV storage class available on from your cluster also allows choosing one that can provide a known
+  ## performant read/write throughput, we recommend at least 3k IOPS, 5MB/sec.
+  persistence:
+    enabled: false
+    storageClass: default
+    size: 100G
+
   ## Uncomment to use custom service account
   # serviceAccountName: default
 

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -78,12 +78,6 @@ sorobanRpc:
     #annotations:
     #  cert-manager.io/cluster-issuer: "default"
 
-  ## Whether to provision persistent volume. Recommended for production use cases. Usage of the PV has benefit of avoiding ephemeral storage, which can vary on different infrastructure and potentially be too low for the combined needs of the rpc and captive core processes. Choosing a PV storage class also allows leveraging any IaaS provided volumes with solid read/write performance.
-  persistence:
-    enabled: false
-    storageClass: default
-    size: 100G
-
   ## Uncomment to use custom service account
   # serviceAccountName: default
 


### PR DESCRIPTION
### What

Temporarily hide persistenct support in the soroban-rpc chart.

### Why

Persistence is not fully tested at this stage so we'd like it to be less visible at this stage.