### PR TITLE
ANCHOR-408 helm-charts/sep-service observer port is fixed

### DIFF
--- a/charts/anchor-platform/sep-service/Chart.yaml
+++ b/charts/anchor-platform/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.95
+version: 0.3.96

--- a/charts/anchor-platform/sep-service/templates/deployment.yaml
+++ b/charts/anchor-platform/sep-service/templates/deployment.yaml
@@ -202,7 +202,7 @@ spec:
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
           - name: metrics
-            containerPort: 8082
+            containerPort: 18083
             protocol: TCP
           {{- if (.Values.deployment).env }}
           env:


### PR DESCRIPTION
This PR fixes the metrics port for the stellar observer services to 18083 since this port is currently hardcoded in the application for now.   This will be released as stellar/sep chart version 0.3.96