### PR TITLE
ANCHOR-403 fix observer deployment annotations

### DIFF
--- a/charts/anchor-platform/sep-service/Chart.yaml
+++ b/charts/anchor-platform/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.96
+version: 0.3.97

--- a/charts/anchor-platform/sep-service/templates/deployment.yaml
+++ b/charts/anchor-platform/sep-service/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
       {{- if (.Values.deployment).annotations }}
       annotations:
       {{- range $key, $value := .Values.deployment.annotations }}
-          {{ $key }}: {{ $value | quote }}
-          {{- end }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if (.Values.deployment).serviceAccountName }}
@@ -146,11 +146,11 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
         {{- end }}
-      {{- if (.Values.deployment).annotations }}
+      {{- if (.Values.stellarObserver.deployment).annotations }}
       annotations:
-        {{- range $key, $value := .Values.deployment.annotations }}
-          {{ $key }}: {{ $value | quote }}
-          {{- end }}
+        {{- range $key, $value := .Values.stellarObserver.deployment.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if (.Values.deployment).serviceAccountName }}


### PR DESCRIPTION
This PR patches an error in the anchor-platform helm chart.  In the stellar observer service, the deployment templates path for pulling annotations from the values file currently pulls those annotations from the sep service values.  This PR patches this error by using annotations from the stellarObserver.deployment values.   This enables you to configure different annotations for both sep service and observer service.  This has been tested using helm-template and deploying the helm chart into a local k8 cluster.