### PR TITLE
Bump soroban-rpc chart version and appVersion

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.1.0-beta.1
-appVersion: "0.8.0"
+version: 0.1.0
+appVersion: "0.9.2"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:
   - name: Stellar Development Foundation


### PR DESCRIPTION
### What

* remove beta from the chart version
* bump appVersion to latest soroban-rpc release

### Why

This will remove the need to use `--devel` flag during deployments using helm install