### PR TITLE
include diagnostic events as values config

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: soroban-rpc
 version: 0.1.0
-appVersion: "0.9.2"
+appVersion: "0.9.3"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -45,6 +45,9 @@ data:
     {{ if (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent -}}
     EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent }}
     {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).enableDiagnosticEvents -}}
+    ENABLE_SOROBAN_DIAGNOSTIC_EVENTS={{ (.Values.sorobanRpc.coreConfig).enableDiagnosticEvents }}
+    {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).httpMaxClient -}}
     HTTP_MAX_CLIENT={{ .Values.sorobanRpc.coreConfig.httpMaxClient }}
     {{ end -}}

--- a/charts/soroban-rpc/testnet-values.yaml
+++ b/charts/soroban-rpc/testnet-values.yaml
@@ -44,6 +44,7 @@ sorobanRpc:
     bucketlistDbIndexPageSizeExponent: 12
     failureSafety: 0
     unsafeQuorum: true
+    enableDiagnosticEvents: true
 
     homeDomains:
       - homeDomain: "testnet.stellar.org"

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -44,6 +44,7 @@ sorobanRpc:
     bucketlistDbIndexPageSizeExponent: 12
     failureSafety: 0
     unsafeQuorum: true
+    enableDiagnosticEvents: true
 
     homeDomains:
     - homeDomain: "futurenet.stellar.org"


### PR DESCRIPTION
the rpc chart should expose the diagnostic events captive core config as a values.yml option.