### PR TITLE
Add soroban-rpc readiness probe

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.9.3"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -32,7 +32,7 @@ data:
     {{ end -}}
     {{ if (.Values.sorobanRpc.sorobanRpcConfig).checkpointFrequence -}}
     CHECKPOINT_FREQUENCY={{ .Values.sorobanRpc.sorobanRpcConfig.checkpointFrequence }}
-    {{ end }}
+    {{- end }}
   stellar-captive-core.cfg: |
     DATABASE="sqlite3:///var/lib/stellar/stellar-captive-core.db"
     HTTP_PORT=11626
@@ -41,7 +41,7 @@ data:
     EXPERIMENTAL_BUCKETLIST_DB=true
     {{ if (.Values.sorobanRpc.coreConfig).bucketDirPath -}}
     BUCKET_DIR_PATH={{ .Values.sorobanRpc.coreConfig.bucketDirPath |quote -}}
-    {{ end }}
+    {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent -}}
     EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT={{ (.Values.sorobanRpc.coreConfig).bucketlistDbIndexPageSizeExponent }}
     {{ end -}}

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -74,7 +74,7 @@ spec:
                     "id": 10235,
                     "method": "getHealth"
                   }' | grep "healthy"
-        {{if (.Values.sorobanRpc).resources}}
+        {{- if (.Values.sorobanRpc).resources}}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}
         {{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -61,6 +61,19 @@ spec:
           name: soroban-rpc
         - containerPort: 6061
           name: admin-port
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                curl --location --request POST 'http://127.0.0.1:8000/' \
+                  --header 'Content-Type: application/json' \
+                  --data-raw '{
+                    "jsonrpc": "2.0",
+                    "id": 10235,
+                    "method": "getHealth"
+                  }' | grep "healthy"
         {{if (.Values.sorobanRpc).resources}}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}


### PR DESCRIPTION
### What

Add soroban-rpc readiness probe

### Why

This will ensure pods are not sent requests until they are ready to handle them correctly.