### PR TITLE
Changed rpc statefulset to deployment

### DIFF
--- a/charts/soroban-rpc/templates/soroban-rpc-deploy.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-deploy.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ template "common.fullname" . }}
   {{- if .Release.Namespace }}
@@ -15,7 +15,8 @@ spec:
   # Currently Soroban RPC doesn't support HA deployments.
   # For that reason we hardcode replicas value at 1
   replicas: 1
-  serviceName: {{ template "common.fullname" . }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ template "common.fullname" . }}
@@ -53,7 +54,7 @@ spec:
           mountPath: /config
           readOnly: true
         {{- if (.Values.sorobanRpc.persistence).enabled }}
-        - name: {{ template "common.fullname" . }}-var-lib-stellar
+        - name: volume-var-lib-stellar
           mountPath: /var/lib/stellar
         {{- end }}
         ports:
@@ -73,8 +74,8 @@ spec:
                     "jsonrpc": "2.0",
                     "id": 10235,
                     "method": "getHealth"
-                  }' | grep "healthy"
-        {{- if (.Values.sorobanRpc).resources}}
+                  }' | grep "jsonrpc"
+        {{- if (.Values.sorobanRpc).resources }}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}
         {{- end }}
@@ -82,14 +83,8 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "common.fullname" . }}
-  {{- if (.Values.sorobanRpc.persistence).enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: {{ template "common.fullname" . }}-var-lib-stellar
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      storageClassName: {{ .Values.sorobanRpc.persistence.storageClass }}
-      resources:
-        requests:
-          storage: {{ .Values.sorobanRpc.persistence.size | quote }}
-  {{- end }}
+      {{- if (.Values.sorobanRpc.persistence).enabled }}
+      - name: volume-var-lib-stellar
+        persistentVolumeClaim:
+          claimName: {{ template "common.fullname" . }}-var-lib-stellar-pvc
+      {{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-pvc.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "common.fullname" . }}-var-lib-stellar-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "common.fullname" . }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.sorobanRpc.persistence.size | quote }}
+  storageClassName: {{ .Values.sorobanRpc.persistence.storageClass }}

--- a/charts/soroban-rpc/values-pubnet.yaml
+++ b/charts/soroban-rpc/values-pubnet.yaml
@@ -201,12 +201,12 @@ sorobanRpc:
   persistence:
     enabled: false
     storageClass: default
-    size: 100G
+    size: 300G
 
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## Additional annotations or labels to add the StatefulSet template
+  ## Additional annotations or labels to add to deployment template
   # annotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "6061"

--- a/charts/soroban-rpc/values-testnet.yaml
+++ b/charts/soroban-rpc/values-testnet.yaml
@@ -92,7 +92,7 @@ sorobanRpc:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## Additional annotations or labels to add the StatefulSet template
+  ## Additional annotations or labels to add the deployment template
   # annotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "6061"

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -92,7 +92,7 @@ sorobanRpc:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## Additional annotations or labels to add the StatefulSet template
+  ## Additional annotations or labels to add to deployment template
   # annotations:
   #   prometheus.io/scrape: "true"
   #   prometheus.io/port: "6061"


### PR DESCRIPTION
To reduce the potential for concurrent access of old/new pods during upgrade strategies of statefulset, we are converting to a deployment for more deterministic Recreate strategy to serialize the old/new pod lifecycle during upgrade.

Closes #79 

tested the chart with template:
```
cat << EOF | helm template soroban-rpc-futurenet-prd ./charts/soroban-rpc --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/values.yaml --values=- >soroban-rpc-futurenet-prd.yml
sorobanRpc:
  ingress:
    ingressClassName: public
    host: soroban-futurenet.stellar.org
  annotations:
    prometheus.io/port: "6061"
    prometheus.io/scrape: "true"
  labels:
    rpc_network: "futurenet"
  resources:
    limits:
      cpu: 1         # Bumped from 250m
      memory: 2560Mi # Bumped from 512Mi
    requests:
      cpu: 50m      # Default
      memory: 384Mi # Bumped from 128Mi
  persistence:
    enabled: true
    storageClass: default
    size: 200G
EOF
```