### PR TITLE
Update RPC chart to use additional zero downtime mechanisms

### DIFF
--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -12,9 +12,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  # Currently Soroban RPC doesn't support HA deployments.
-  # For that reason we hardcode replicas value at 1
-  replicas: 1
+  # Currently Soroban RPC doesn't support HA deployments over a single shared data store
+  # but, each replica pod in a statefulset will have it's own data store on it's PVC.
+  # This statefulset creates two replicas which will be monitored by the readiness probe. 
+  # Having two replicas also ensures zero downtime during upgrades as at least one replica is 
+  # gauranteed to be running while the other one is upgraded and catching backup to network 
+  # after restart
+  replicas: 2
   serviceName: {{ template "common.fullname" . }}
   selector:
     matchLabels:
@@ -73,7 +77,11 @@ spec:
                     "jsonrpc": "2.0",
                     "id": 10235,
                     "method": "getHealth"
-                  }' | grep "healthy"
+                  }' | jq -es 'if (. | length) == 0 then null else .[0] end | .result | .status == "healthy" and (.latestLedger - .oldestLedger >= (.ledgerRetentionWindow - 10))' > /dev/null;
+          failureThreshold: 2
+          periodSeconds: 10
+          successThreshold: 2
+          timeoutSeconds: 5         
         {{- if (.Values.sorobanRpc).resources}}
         resources:
 {{ toYaml .Values.sorobanRpc.resources | indent 10 }}


### PR DESCRIPTION
Update the rpc chart to include an updates of the statefulset that assist for better zero downtime of rpc at runtime and upgrade time:

* default the sts to replicas=2, this will help ensure zero downtime during upgrades, as the sts controller can always keep one replica pod up while it updates the other, as updating a pod requires restart, which also incurs a captive core catchup/sync which can be significant time that the instance is not passing readiness during that startup time.
* leverage new rpc health status info to verify `retention window fully populated` condition into the readiness probe check 

These changes have been verified on cluster deployments using the same changes directly through k8s manifests:
https://github.com/stellar/kube/pull/2098

Closes #82 