### PR TITLE
Add update completed sprint action

### DIFF
--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -1,0 +1,25 @@
+name: Update CompletedSprint on Issue Closed
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  update-completed-sprint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
+          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
+      - name: Update CompletedSprint on Issue Closed
+        id: update_completedsprint_on_issue_closed
+        uses: stellar/actions/update-completed-sprint-on-issue-closed@main
+        with:
+          project_name: "Platform Scrum"
+          field_name: "CompletedSprint"
+          project_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This is a github action that Platform team uses across several other repos to do some sprint tracking/housekeeping and we'd like to enable it in this repo as well.

Note that this will require someone from the @stellar/ops-team to enable github project management for this repo, instructions here https://stellarorg.atlassian.net/wiki/spaces/OT/pages/4545642505/Github#Github-project-management