### PR TITLE
[SDP-1236] Fix SDP helm chart defaults and minimal-values

### DIFF
--- a/charts/stellar-disbursement-platform/Chart.yaml
+++ b/charts/stellar-disbursement-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stellar-disbursement-platform
 description: A Helm chart for the Stellar Disbursement Platform Backend (A.K.A. `sdp`)
-version: 2.0.0
+version: 2.0.1
 appVersion: "2.0.0"
 type: application
 maintainers:

--- a/charts/stellar-disbursement-platform/minimal-values.yaml
+++ b/charts/stellar-disbursement-platform/minimal-values.yaml
@@ -10,14 +10,7 @@ global:
   ## @param global.eventBroker.urls A comma-separated list of broker URLs for the event broker.
   ## @param global.eventBroker.consumerGroupId The consumer group ID for the event broker.
   eventBroker:
-    type: "KAFKA"
-    urls: #required
-    consumerGroupId: #required
-
-    ## @extra global.eventBroker.kafka Configuration related to the Kafka event broker.
-    ## @param global.eventBroker.kafka.securityProtocol The security protocol to be used for the Kafka broker. Options: "PLAINTEXT", "SASL_SSL", "SASL_PLAINTEXT", "SSL".
-    kafka:
-      securityProtocol: #required
+    type: "NONE"
 
 sdp:
 
@@ -27,6 +20,7 @@ sdp:
     domain: #required
     mtnDomain: #required
 
+  ## @param sdp.configMap.data.ENABLE_SCHEDULER Whether the scheduled jobs are enabled in this instance ("true" or "false"). Setting to "true" because broker type is `NONE`.
   ## @param sdp.configMap.data.EC256_PUBLIC_KEY [string] The EC256 public key used for authentication purposes.
   ## @param sdp.configMap.data.SEP10_SIGNING_PUBLIC_KEY Anchor platform SEP10 signing public key.
   ## @param sdp.configMap.data.DISTRIBUTION_PUBLIC_KEY The public key of the Stellar distribution account that sends the Stellar payments.
@@ -35,6 +29,7 @@ sdp:
   configMap:
     annotations:
     data:
+      ENABLE_SCHEDULER: "true"
       EC256_PUBLIC_KEY: #required
       SEP10_SIGNING_PUBLIC_KEY: #required
       DISTRIBUTION_PUBLIC_KEY: #required
@@ -48,10 +43,12 @@ sdp:
   ## @param sdp.kubeSecrets.data.ANCHOR_PLATFORM_OUTGOING_JWT_SECRET The JWT secret used to create a JWT token used to send requests to the anchor platform.
   ## @param sdp.kubeSecrets.data.DATABASE_URL URL of the database used by the SDP.
   ## @param sdp.kubeSecrets.data.DISTRIBUTION_SEED The private key of the Stellar account used to disburse funds. This is needed for the init container
+  ## @param sdp.kubeSecrets.data.DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE The private key used to encrypt the distribution accounts secrets in the database, mandatory when DISTRIBUTION_SIGNER_TYPE is set to DISTRIBUTION_ACCOUNT_DB.
   ## @param sdp.kubeSecrets.data.CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE The private key used to encrypt the channel account secrets in the database.
   ## @param sdp.kubeSecrets.data.ADMIN_ACCOUNT The ID of the admin account. To use, add to the request header as 'Authorization', formatted as Base64-encoded 'ADMIN_ACCOUNT:ADMIN_API_KEY'.",
   ## @param sdp.kubeSecrets.data.ADMIN_API_KEY The API key for the admin account. To use, add to the request header as 'Authorization', formatted as Base64-encoded 'ADMIN_ACCOUNT:ADMIN_API_KEY'.",
   kubeSecrets:
+    secretName: sdp
     create: true
     data:
       EC256_PRIVATE_KEY: #required
@@ -61,6 +58,7 @@ sdp:
       ANCHOR_PLATFORM_OUTGOING_JWT_SECRET: #required for mySdpToAnchorPlatformSecret
       DATABASE_URL: #required
       DISTRIBUTION_SEED: #required
+      DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE: #required
       CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE: #required
       ADMIN_ACCOUNT: #required
       ADMIN_API_KEY: #required
@@ -88,6 +86,7 @@ anchorPlatform:
   ## @param anchorPlatform.kubeSecrets.data.SECRET_SEP24_INTERACTIVE_URL_JWT_SECRET The JWT secret used by the Anchor Platform to sign SEP-24 interactive URLs. These URLs typically initiate user-interactive processes like deposits and withdrawals.
   ## @param anchorPlatform.kubeSecrets.data.SECRET_SEP24_MORE_INFO_URL_JWT_SECRET The JWT secret used by the Anchor Platform to sign SEP-24 'More Info' URLs. These URLs provide users with additional details or steps related to their transactions.
   kubeSecrets:
+    secretName: sdp-ap
     create: true
     data:
       SECRET_DATA_PASSWORD: #required
@@ -111,12 +110,15 @@ tss:
 
   ## @param tss.kubeSecrets.data.DATABASE_URL URL of the database used by the TSS.
   ## @param tss.kubeSecrets.data.DISTRIBUTION_SEED The private key of the Stellar account used to disburse funds.
+  ## @param tss.kubeSecrets.data.DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE The private key used to encrypt the distribution accounts secrets in the database, mandatory when DISTRIBUTION_SIGNER_TYPE is set to DISTRIBUTION_ACCOUNT_DB.
   ## @param tss.kubeSecrets.data.CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE The private key used to encrypt the channel account secrets in the database.
   kubeSecrets:
+    secretName: sdp-tss
     create: true
     data:
       DATABASE_URL: #required
       DISTRIBUTION_SEED: #required
+      DISTRIBUTION_ACCOUNT_ENCRYPTION_PASSPHRASE: #required
       CHANNEL_ACCOUNT_ENCRYPTION_PASSPHRASE: #required
 
 dashboard:

--- a/charts/stellar-disbursement-platform/templates/05.1-secrets-sdp.yaml
+++ b/charts/stellar-disbursement-platform/templates/05.1-secrets-sdp.yaml
@@ -16,7 +16,9 @@ metadata:
 {{- if .Values.sdp.kubeSecrets.data }}
 data:
   {{- range $key, $value := .Values.sdp.kubeSecrets.data }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+    {{- if $value }}
+      {{ $key }}: {{ $value | b64enc | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/stellar-disbursement-platform/templates/05.2-secrets-ap.yaml
+++ b/charts/stellar-disbursement-platform/templates/05.2-secrets-ap.yaml
@@ -13,10 +13,12 @@ metadata:
     {{- toYaml .Values.anchorPlatform.kubeSecrets.annotations | nindent 4 }}
   {{- end }}
 
-{{- if .Values.anchorPlatform.configMap.data }}
+{{- if .Values.anchorPlatform.kubeSecrets.data }}
 data:
-  {{- range $key, $value := .Values.anchorPlatform.configMap.data }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- range $key, $value := .Values.anchorPlatform.kubeSecrets.data }}
+    {{- if $value }}
+      {{ $key }}: {{ $value | b64enc | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/stellar-disbursement-platform/templates/05.3-secrets-tss.yaml
+++ b/charts/stellar-disbursement-platform/templates/05.3-secrets-tss.yaml
@@ -16,7 +16,9 @@ metadata:
 {{- if .Values.tss.kubeSecrets.data }}
 data:
   {{- range $key, $value := .Values.tss.kubeSecrets.data }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+    {{- if $value }}
+      {{ $key }}: {{ $value | b64enc | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
* Small fixes when running this Chart using the minimal-values.yaml
* Changed default background job processing to `Scheduler` instead of `Kafka` for an easier minimal setup
* Fixed Anchor secrets that were being generated from the ConfigMap 

### Testing this locally 
1. Pre-requisites
   1. `docker desktop` 
   2. `kubectl`  in command line 
   3. `helm` in command line 

2. Enable Kubernetes in docker-desktop settings 

3. Switch to `docker-desktop` kubernetes context 
```
kubectl config use-context docker-desktop
```

4. Install the Stellar helm chart

* Add the Stellar helm repository
```
helm repo add stellar https://helm.stellar.org/charts
```

* Copy minimal values 
```
curl -LJO https://raw.githubusercontent.com/stellar/stellar-disbursement-platform-backend/develop/helmchart/sdp/minimal-values.yaml
```

* Customize minimal values

5. Install SDP 
```
helm install sdp -f minimal-values.yaml stellar/stellar-disbursement-platform
```

<img width="894" alt="Screenshot 2024-06-10 at 5 57 02 PM" src="https://github.com/stellar/helm-charts/assets/4129193/4972c690-ab02-45c6-b10d-5dc07c452c78">
