### PR TITLE
SDP-1280 Fix duplicate base_url in SDP helm chart

### DIFF
--- a/charts/stellar-disbursement-platform/Chart.yaml
+++ b/charts/stellar-disbursement-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stellar-disbursement-platform
 description: A Helm chart for the Stellar Disbursement Platform Backend (A.K.A. `sdp`)
-version: 2.0.1
+version: 2.0.2
 appVersion: "2.0.0"
 type: application
 maintainers:

--- a/charts/stellar-disbursement-platform/values.yaml
+++ b/charts/stellar-disbursement-platform/values.yaml
@@ -156,7 +156,6 @@ sdp:
   configMap:
     annotations:
     data:
-      BASE_URL: "http://localhost:8000"
       CRASH_TRACKER_TYPE: "DRY_RUN"
       EC256_PUBLIC_KEY: #required
       ENVIRONMENT: "dev"


### PR DESCRIPTION
This issue is encountered by the UNICC - because of a different post render validation used by flux 
https://github.com/fluxcd/helm-controller/issues/283

This was the way to reproduce the issue using kustomize. 

### Prepare `kustomize.sh` and `kustomization.yaml` 
```
cat > kustomize.sh <<\EOT
#!/bin/bash
cat - > helm-generated-output.yaml
kustomize build . && rm helm-generated-output.yaml
EOT
chmod +x kustomize.sh

cat > kustomization.yaml <<\EOT
resources:
- helm-generated-output.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
patches: []
EOT
``` 

### Run helm template
```
helm template sdp . --post-renderer ./kustomize.sh -f myvalues.yaml
```

### Error on duplicate BASE_URL
```
Error: error while running post render on files: error while running command /Users/.../dev/helm-charts/charts/stellar-disbursement-platform/kustomize.sh. error output:
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 26: mapping key "BASE_URL" already defined at line 16
: exit status 1

Use --debug flag to render out invalid YAML
```
