### PR TITLE
Change Pubnet config to `PUBLIC` for SDP

### DIFF
--- a/charts/stellar-disbursement-platform/Chart.yaml
+++ b/charts/stellar-disbursement-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stellar-disbursement-platform
 description: A Helm chart for the Stellar Disbursement Platform Backend (A.K.A. `sdp`)
-version: 2.0.2
+version: 2.0.3
 appVersion: "2.0.0"
 type: application
 maintainers:

--- a/charts/stellar-disbursement-platform/templates/01.2-configmap-ap.yaml
+++ b/charts/stellar-disbursement-platform/templates/01.2-configmap-ap.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   # if {{ include "isPubnet" . }} is true, then the network is set to PUBNET, else it's all TESTNET
   {{- if eq (include "isPubnet" .) "true" }}
-  STELLAR_NETWORK_NETWORK: "PUBNET"
+  STELLAR_NETWORK_NETWORK: "PUBLIC"
   STELLAR_NETWORK_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
   STELLAR_NETWORK_HORIZON_URL: "https://horizon.stellar.org"
   {{- else }}


### PR DESCRIPTION
It's looking like that value for anchor is `PUBLIC` not `PUBNET` https://github.com/stellar/java-stellar-anchor-sdk/blob/0d81cff3fd00a90114ac2a758ea37aea0528a5e5/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAppConfig.java#L93