### PR TITLE
Clean up namespace templating in horizon chart

### DIFF
--- a/charts/horizon/templates/horizon-core-cm.yaml
+++ b/charts/horizon/templates/horizon-core-cm.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "common.fullname" . }}-core
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-core
     chart: {{ template "common.chart" . }}

--- a/charts/horizon/templates/horizon-ingest-cm.yaml
+++ b/charts/horizon/templates/horizon-ingest-cm.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "common.fullname" . }}-ingest-env
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-ingest
     chart: {{ template "common.chart" . }}

--- a/charts/horizon/templates/horizon-ingest-sts.yaml
+++ b/charts/horizon/templates/horizon-ingest-sts.yaml
@@ -4,9 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "common.fullname" . }}-ingest
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-ingest
     chart: {{ template "common.chart" . }}
@@ -114,9 +112,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.fullname" . }}-ingest-core
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-ingest-core
     chart: {{ template "common.chart" . }}
@@ -135,9 +131,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.fullname" . }}-ingest
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-ingest
     chart: {{ template "common.chart" . }}

--- a/charts/horizon/templates/horizon-ingress.yaml
+++ b/charts/horizon/templates/horizon-ingress.yaml
@@ -4,9 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "common.fullname" . }}-ingest
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   {{- if (.Values.ingest.ingress).annotations }}
   annotations:
     {{- range $key, $value := .Values.ingest.ingress.annotations }}
@@ -36,9 +34,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "common.fullname" . }}-web
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   {{- if (.Values.web.ingress).annotations }}
   annotations:
     {{- range $key, $value := .Values.web.ingress.annotations }}

--- a/charts/horizon/templates/horizon-web-cm.yaml
+++ b/charts/horizon/templates/horizon-web-cm.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "common.fullname" . }}-web-env
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-web
     chart: {{ template "common.chart" . }}

--- a/charts/horizon/templates/horizon-web-deployment.yaml
+++ b/charts/horizon/templates/horizon-web-deployment.yaml
@@ -4,9 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "common.fullname" . }}-web
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-web
     chart: {{ template "common.chart" . }}
@@ -77,9 +75,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.fullname" . }}-web
-  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
     app: {{ template "common.fullname" . }}-web
     chart: {{ template "common.chart" . }}

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -1,8 +1,4 @@
 global:
-  ## String to use to explicitly set namespace name in manifests.
-  ## Useful for those using "helm template" to render templates
-  # namespace: mynamespace
-
   ## Stellar network to use. When set to "testnet" or "pubnet" default
   ## recommended config will be used.
   ## When set to any other value you have to provide extra settings:


### PR DESCRIPTION
This PR cleans up the namespace use in the horizon chart

The release namespace will always be populated with the kubernetes namespace where the chart is being used. There was also a value that did not seem to be used anywhere