### PR TITLE
Clean up image values for horizon chart

### DIFF
--- a/charts/horizon/templates/_helpers.tpl
+++ b/charts/horizon/templates/_helpers.tpl
@@ -20,7 +20,7 @@
 {{- end -}}
 
 {{- define "common.horizonImage" -}}
-{{ .Values.global.image.horizon.registry }}/{{ .Values.global.image.horizon.repository }}:{{ default .Chart.AppVersion .Values.global.image.horizon.tag }}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
 {{- end -}}
 
 {{- define "core.config" -}}

--- a/charts/horizon/templates/ingest-statefulset.yaml
+++ b/charts/horizon/templates/ingest-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
           - {{ $flag | quote }}
           {{- end }}
         {{- end }}
-        imagePullPolicy: {{ .Values.global.image.horizon.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.ingest.horizonConfig.port | default 8000 }}
           name: horizon
@@ -82,8 +82,8 @@ spec:
         {{- end }}
       {{- if .Values.ingest.coreExporter.enabled }}
       - name: stellar-core-prometheus-exporter
-        image: "{{ .Values.global.image.coreExporter.registry }}/{{ .Values.global.image.coreExporter.repository }}:{{ .Values.global.image.coreExporter.tag }}"
-        imagePullPolicy: {{ .Values.global.image.coreExporter.pullPolicy }}
+        image: "{{ .Values.ingest.coreExporter.image.registry }}/{{ .Values.ingest.coreExporter.image.repository }}:{{ .Values.ingest.coreExporter.image.tag }}"
+        imagePullPolicy: {{ .Values.ingest.coreExporter.image.pullPolicy }}
         ports:
         - containerPort: 9473
           name: metrics

--- a/charts/horizon/templates/web-deployment.yaml
+++ b/charts/horizon/templates/web-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - {{ $flag | quote }}
           {{- end }}
         {{- end }}
-        imagePullPolicy: {{ .Values.global.image.horizon.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.web.horizonConfig.port | default 8000 }}
           name: horizon

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -24,30 +24,15 @@ global:
   # - imagepullsecret1
   # - imagepullsecret2
 
-  image:
-    horizon:
-      registry: docker.io
-      repository: stellar/stellar-horizon
-      ## Optional tag. Defaults to the appVersion from Chart.yaml
-      # tag: 1.2.3
-
-      ## Specify a imagePullPolicy
-      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-      ##
-      pullPolicy: Always
-    coreExporter:
-      registry: docker.io
-      repository: stellar/stellar-core-prometheus-exporter
-      tag: latest
-      ## Specify a imagePullPolicy
-      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-      ##
-      pullPolicy: Always
+image:
+  registry: docker.io
+  repository: stellar/stellar-horizon
+  ## Optional tag. Defaults to the appVersion from Chart.yaml
+  # tag: 1.2.3
+  pullPolicy: Always
 
 ingest:
-  ## See global.image.horizon for image settings
+  ## See image for image settings
 
   ## Whether to deploy ingesting instances
   enabled: true
@@ -118,7 +103,11 @@ ingest:
     ## If you'd like to have prometheus
     enabled: true
 
-    ## See global.image.coreExporter for image settings
+    image:
+      registry: docker.io
+      repository: stellar/stellar-core-prometheus-exporter
+      tag: latest
+      pullPolicy: Always
 
     ## Uncomment to set resource limits
     #resources:
@@ -130,7 +119,7 @@ ingest:
     #    memory: 128Mi
 
 web:
-  ## See global.image.horizon for image settings
+  ## See image for image settings
 
   ## Whether to deploy non-ingesting instances
   ## Useful with read-only DB replica


### PR DESCRIPTION
This PR cleans up how the image values are structured in the horizon chart

global is a section used to communicate values between charts. The container image horizon should not be overwritten by other charts. In addition the core exporter image is only used in one place