### PR TITLE
Push config defaults to the default values file in horizon

### DIFF
--- a/charts/horizon/templates/ingest-configmap.yaml
+++ b/charts/horizon/templates/ingest-configmap.yaml
@@ -11,35 +11,33 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ADMIN_PORT: {{ .Values.ingest.horizonConfig.adminPort | default "6000" | quote}}
-  APPLY_MIGRATIONS: {{ .Values.ingest.horizonConfig.applyMigrations | default "false" | quote}}
-  ALLOW_EMPTY_LEDGER_DATA_RESPONSES: {{ .Values.ingest.horizonConfig.allowEmptyLedgerDataResponses | default "true" | quote}}
+  ADMIN_PORT: {{ .Values.ingest.config.adminPort | quote}}
+  APPLY_MIGRATIONS: {{ .Values.ingest.config.applyMigrations | quote}}
+  ALLOW_EMPTY_LEDGER_DATA_RESPONSES: {{ .Values.ingest.config.allowEmptyLedgerDataResponses | quote}}
   CAPTIVE_CORE_CONFIG_APPEND_PATH: "/config/stellar-core.cfg"
   CAPTIVE_CORE_REUSE_STORAGE_PATH: "True"
   CAPTIVE_CORE_REUSE_STORAGE_DIR: "True"
   CAPTIVE_CORE_STORAGE_PATH: "/var/lib/stellar"
-  CAPTIVE_CORE_USE_DB: {{ .Values.ingest.horizonConfig.captiveCoreUseDb | default "False" | quote}}
-  CONNECTION_TIMEOUT: {{ .Values.ingest.horizonConfig.connectionTimeout | default "10" | quote}}
-  {{- if .Values.ingest.horizonConfig.disablePathFinding }}
-  DISABLE_PATH_FINDING: {{ .Values.ingest.horizonConfig.disablePathFinding | default "False" | quote}}
-  {{- end }}
-  ENABLE_ACCOUNTS_FOR_SIGNER: {{ .Values.ingest.horizonConfig.enableAccountsForSigner | default "false" | quote}}
-  ENABLE_ASSET_STATS: {{ .Values.ingest.horizonConfig.enableAssetStats | default "true" | quote}}
+  CAPTIVE_CORE_USE_DB: {{ .Values.ingest.config.captiveCoreUseDb | quote}}
+  CONNECTION_TIMEOUT: {{ .Values.ingest.config.connectionTimeout | quote}}
+  DISABLE_PATH_FINDING: {{ .Values.ingest.config.disablePathFinding | quote}}
+  ENABLE_ACCOUNTS_FOR_SIGNER: {{ .Values.ingest.config.enableAccountsForSigner | quote}}
+  ENABLE_ASSET_STATS: {{ .Values.ingest.config.enableAssetStats | quote}}
   ENABLE_CAPTIVE_CORE_INGESTION: "true"
   ENABLE_EXPERIMENTAL_INGESTION: "false"
-  {{- if .Values.ingest.horizonConfig.friendbotUrl }}
-  FRIENDBOT_URL: {{ .Values.ingest.horizonConfig.friendbotUrl | default "https://friendbot.stellar.org" | quote}}
+  {{- if .Values.ingest.config.friendbotUrl }}
+  FRIENDBOT_URL: {{ .Values.ingest.config.friendbotUrl | quote}}
   {{- end }}
   HISTORY_ARCHIVE_URLS: {{ include "horizon.historyArchiveUrls" . | quote }}
-  HISTORY_RETENTION_COUNT: {{ .Values.ingest.horizonConfig.historyRetentionCount | default "34560" | quote}}
-  INGEST_FAILED_TRANSACTIONS: {{ .Values.ingest.horizonConfig.ingestFailedTransactions | default "true" | quote}}
+  HISTORY_RETENTION_COUNT: {{ .Values.ingest.config.historyRetentionCount | quote}}
+  INGEST_FAILED_TRANSACTIONS: {{ .Values.ingest.config.ingestFailedTransactions | quote}}
   INGEST: "true"
-  MAX_DB_CONNECTIONS: {{ .Values.ingest.horizonConfig.maxDBConnections | default "20" | quote}}
+  MAX_DB_CONNECTIONS: {{ .Values.ingest.config.maxDBConnections | quote}}
   NETWORK_PASSPHRASE: {{ include "horizon.networkPassphrase" . | quote }}
-  PER_HOUR_RATE_LIMIT: {{ .Values.ingest.horizonConfig.perHourRateLimit | default "3600" | quote}}
-  PORT: {{ .Values.ingest.horizonConfig.port | default "8000" | quote}}
-  SSE_UPDATE_FREQUENCY: {{ .Values.ingest.horizonConfig.SseUpdateFrequency | default "4" | quote}}
+  PER_HOUR_RATE_LIMIT: {{ .Values.ingest.config.perHourRateLimit | quote}}
+  PORT: {{ .Values.ingest.config.port | quote}}
+  SSE_UPDATE_FREQUENCY: {{ .Values.ingest.config.sseUpdateFrequency | quote}}
   STELLAR_CORE_BINARY_PATH: "/usr/bin/stellar-core"
-  STELLAR_CORE_URL: {{ .Values.ingest.horizonConfig.stellarCoreUrl | default "http://127.0.0.1:11626" | quote}}
+  STELLAR_CORE_URL: {{ .Values.ingest.config.stellarCoreUrl | quote}}
   TMPDIR: "/var/lib/stellar"
 {{- end }}

--- a/charts/horizon/templates/ingest-statefulset.yaml
+++ b/charts/horizon/templates/ingest-statefulset.yaml
@@ -52,9 +52,9 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.horizon.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.ingest.horizonConfig.port | default 8000 }}
+        - containerPort: {{ .Values.ingest.config.port }}
           name: horizon
-        - containerPort: {{ .Values.ingest.horizonConfig.adminPort | default 6000 }}
+        - containerPort: {{ .Values.ingest.config.adminPort }}
           name: metrics
         - containerPort: 11626
           name: core
@@ -65,7 +65,7 @@ spec:
             name: {{ template "common.fullname" . }}-ingest-env
         readinessProbe:
           httpGet:
-            port: {{ .Values.ingest.horizonConfig.port | default 8000 }}
+            port: {{ .Values.ingest.config.port }}
             path: /health
           initialDelaySeconds: 5
           timeoutSeconds: 5
@@ -142,7 +142,7 @@ spec:
   ports:
     - name: horizon
       port: 80
-      targetPort: {{ .Values.ingest.horizonConfig.port | default 8000 }}
+      targetPort: {{ .Values.ingest.config.port }}
   selector:
     app: {{ template "common.fullname" . }}-ingest
 {{- end }}

--- a/charts/horizon/templates/web-configmap.yaml
+++ b/charts/horizon/templates/web-configmap.yaml
@@ -11,22 +11,22 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  ADMIN_PORT: {{ .Values.web.config.adminPort | quote}}
+  ALLOW_EMPTY_LEDGER_DATA_RESPONSES: {{ .Values.web.config.allowEmptyLedgerDataResponses | quote}}
+  CONNECTION_TIMEOUT: {{ .Values.web.config.connectionTimeout | quote}}
+  ENABLE_ACCOUNTS_FOR_SIGNER: {{ .Values.web.config.enableAccountsForSigner | quote}}
+  ENABLE_ASSET_STATS: {{ .Values.web.config.enableAssetStats | quote}}
+  HISTORY_ARCHIVE_URLS: {{ include "horizon.historyArchiveUrls" . | quote }}
   INGEST: "false"
-  PORT: {{ .Values.web.horizonConfig.port | default "8000" | quote}}
-  ADMIN_PORT: {{ .Values.web.horizonConfig.adminPort | default "6000" | quote}}
-  {{ if .Values.web.horizonConfig.stellarCoreUrl -}}
-  STELLAR_CORE_URL: {{ .Values.web.horizonConfig.stellarCoreUrl | quote}}
+  MAX_DB_CONNECTIONS: {{ .Values.web.config.maxDBConnections | quote}}
+  MAX_PATH_LENGTH: {{ .Values.web.config.maxPathLength | quote}}
+  NETWORK_PASSPHRASE: {{ include "horizon.networkPassphrase" . | quote }}
+  PER_HOUR_RATE_LIMIT: {{ .Values.web.config.perHourRateLimit | quote}}
+  PORT: {{ .Values.web.config.port | quote}}
+  SSE_UPDATE_FREQUENCY: {{ .Values.web.config.sseUpdateFrequency | quote}}
+  {{ if .Values.web.config.stellarCoreUrl -}}
+  STELLAR_CORE_URL: {{ .Values.web.config.stellarCoreUrl | quote}}
   {{- else }}
   STELLAR_CORE_URL: http://{{ template "common.fullname" . }}-ingest-core:11626
   {{- end }}
-  PER_HOUR_RATE_LIMIT: {{ .Values.web.horizonConfig.perHourRateLimit | default "8000" | quote}}
-  MAX_DB_CONNECTIONS: {{ .Values.web.horizonConfig.maxDBConnections | default "20" | quote}}
-  SSE_UPDATE_FREQUENCY: {{ .Values.web.horizonConfig.SseUpdateFrequency | default "4" | quote}}
-  CONNECTION_TIMEOUT: {{ .Values.web.horizonConfig.connectionTimeout | default "10" | quote}}
-  ALLOW_EMPTY_LEDGER_DATA_RESPONSES: {{ .Values.web.horizonConfig.allowEmptyLedgerDataResponses | default "true" | quote}}
-  ENABLE_ASSET_STATS: {{ .Values.web.horizonConfig.enableAssetStats | default "true" | quote}}
-  ENABLE_ACCOUNTS_FOR_SIGNER: {{ .Values.web.horizonConfig.enableAccountsForSigner | default "false" | quote}}
-  MAX_PATH_LENGTH: {{ .Values.web.horizonConfig.maxPathLength | default "3" | quote}}
-  HISTORY_ARCHIVE_URLS: {{ include "horizon.historyArchiveUrls" . | quote }}
-  NETWORK_PASSPHRASE: {{ include "horizon.networkPassphrase" . | quote }}
 {{- end }}

--- a/charts/horizon/templates/web-deployment.yaml
+++ b/charts/horizon/templates/web-deployment.yaml
@@ -51,9 +51,9 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.horizon.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.web.horizonConfig.port | default 8000 }}
+        - containerPort: {{ .Values.web.config.port }}
           name: horizon
-        - containerPort: {{ .Values.web.horizonConfig.adminPort | default 6000 }}
+        - containerPort: {{ .Values.web.config.adminPort }}
           name: metrics
         envFrom:
         - secretRef:
@@ -62,7 +62,7 @@ spec:
             name: {{ template "common.fullname" . }}-web-env
         readinessProbe:
           httpGet:
-            port: {{ .Values.web.horizonConfig.port | default 8000 }}
+            port: {{ .Values.web.config.port }}
             path: /health
           initialDelaySeconds: 5
           timeoutSeconds: 5
@@ -86,7 +86,7 @@ spec:
   ports:
     - name: core
       port: 80
-      targetPort: {{ .Values.web.horizonConfig.port | default 8000 }}
+      targetPort: {{ .Values.web.config.port }}
   selector:
     app: {{ template "common.fullname" . }}-web
 {{- end }}

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -56,11 +56,24 @@ ingest:
   cliArgs:
   - "--apply-migrations"
 
-  ## This variable allows overrides of default settings
-  horizonConfig:
+  ## Horizon config
+  config:
+    adminPort: 6000
+    allowEmptyLedgerDataResponses: true
     applyMigrations: false
-    # port: 8001
-
+    captiveCoreUseDb: false
+    connectionTimeout: 10
+    disablePathFinding: false
+    enableAccountsForSigner: false
+    enableAssetStats: true
+    friendbotUrl: ""
+    historyRetentionCount: 34560
+    ingestFailedTransactions: true
+    maxDBConnections: 20
+    perHourRateLimit: 3600
+    port: 8000
+    sseUpdateFrequency: 4
+    stellarCoreUrl: "http://127.0.0.1:11626"
 
   ## pre existing secret that contains the DATABASE_URL key with postgres URL
   existingSecret: ""
@@ -139,10 +152,19 @@ web:
   ## List of CLI arguments to provide to the stellar-horizon binary
   # cliArgs: []
 
-  ## This variable allows overrides of default settings
-  horizonConfig:
-    {}
-    # port: 8001
+  ## Horizon config
+  config:
+    adminPort: 6000
+    allowEmptyLedgerDataResponses: true
+    connectionTimeout: 10
+    enableAccountsForSigner: false
+    enableAssetStats: true
+    maxDBConnections: 20
+    maxPathLength: 3
+    perHourRateLimit: 8000
+    port: 8000
+    sseUpdateFrequency: 4
+    stellarCoreUrl: "" # defaults to igest's core instance
 
   ## pre existing secret that contains the DATABASE_URL key with postgres URL
   existingSecret: ""


### PR DESCRIPTION
This PR brings the config options and defaults up to the default helm values file

Currently there is no documentation of all of the config options in the values file. In addition the configmaps actually take specific values and are not open ended. This PR makes it easier to see what values are actually being used
This also alphabetizes the web config and removes an unused if statement