### PR TITLE
Break horizon resources into separate files

### DIFF
--- a/charts/horizon/templates/core-configmap.yaml
+++ b/charts/horizon/templates/core-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingest.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -12,3 +13,4 @@ metadata:
 data:
   stellar-core.cfg: |
 {{ include "core.config" . | indent 4 }}
+{{- end }}

--- a/charts/horizon/templates/ingest-core-service.yaml
+++ b/charts/horizon/templates/ingest-core-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingest.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.fullname" . }}-ingest-core
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "common.fullname" . }}-ingest-core
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: core
+      port: 11626
+      targetPort: 11626
+  selector:
+    app: {{ template "common.fullname" . }}-ingest
+{{- end }}

--- a/charts/horizon/templates/ingest-ingress.yaml
+++ b/charts/horizon/templates/ingest-ingress.yaml
@@ -28,33 +28,3 @@ spec:
             port:
               number: 80
 {{- end }}
-{{- if and .Values.web.enabled .Values.web.ingress.enabled }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ template "common.fullname" . }}-web
-  namespace: {{ .Release.Namespace }}
-  {{- if .Values.web.ingress.annotations }}
-  annotations:
-    {{- range $key, $value := .Values.web.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- end }}
-spec:
-  tls:
-  - secretName: {{ template "common.fullname" . }}-web-cert
-    hosts:
-    - {{ .Values.web.ingress.host }}
-  rules:
-  - host: {{ .Values.web.ingress.host }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ template "common.fullname" . }}-web
-            port:
-              number: 80
-{{- end }}

--- a/charts/horizon/templates/ingest-service.yaml
+++ b/charts/horizon/templates/ingest-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingest.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.fullname" . }}-ingest
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "common.fullname" . }}-ingest
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: horizon
+      port: 80
+      targetPort: {{ .Values.ingest.config.port }}
+  selector:
+    app: {{ template "common.fullname" . }}-ingest
+{{- end }}

--- a/charts/horizon/templates/ingest-statefulset.yaml
+++ b/charts/horizon/templates/ingest-statefulset.yaml
@@ -107,42 +107,4 @@ spec:
         requests:
           storage: {{ .Values.ingest.persistence.size | quote }}
   {{- end }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "common.fullname" . }}-ingest-core
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "common.fullname" . }}-ingest-core
-    chart: {{ template "common.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  type: ClusterIP
-  ports:
-    - name: core
-      port: 11626
-      targetPort: 11626
-  selector:
-    app: {{ template "common.fullname" . }}-ingest
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "common.fullname" . }}-ingest
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "common.fullname" . }}-ingest
-    chart: {{ template "common.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  type: ClusterIP
-  ports:
-    - name: horizon
-      port: 80
-      targetPort: {{ .Values.ingest.horizonConfig.port | default 8000 }}
-  selector:
-    app: {{ template "common.fullname" . }}-ingest
 {{- end }}

--- a/charts/horizon/templates/web-deployment.yaml
+++ b/charts/horizon/templates/web-deployment.yaml
@@ -70,23 +70,4 @@ spec:
         resources:
 {{ toYaml .Values.web.resources | indent 10 }}
         {{- end }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "common.fullname" . }}-web
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "common.fullname" . }}-web
-    chart: {{ template "common.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  type: ClusterIP
-  ports:
-    - name: core
-      port: 80
-      targetPort: {{ .Values.web.horizonConfig.port | default 8000 }}
-  selector:
-    app: {{ template "common.fullname" . }}-web
 {{- end }}

--- a/charts/horizon/templates/web-ingress.yaml
+++ b/charts/horizon/templates/web-ingress.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.web.enabled .Values.web.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "common.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.web.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.web.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  tls:
+  - secretName: {{ template "common.fullname" . }}-web-cert
+    hosts:
+    - {{ .Values.web.ingress.host }}
+  rules:
+  - host: {{ .Values.web.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "common.fullname" . }}-web
+            port:
+              number: 80
+{{- end }}

--- a/charts/horizon/templates/web-service.yaml
+++ b/charts/horizon/templates/web-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.web.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "common.fullname" . }}-web
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: core
+      port: 80
+      targetPort: {{ .Values.web.config.port }}
+  selector:
+    app: {{ template "common.fullname" . }}-web
+{{- end }}


### PR DESCRIPTION
This PR breaks the horizon resources into separate templates

Currently the chart has some collections of resources in files that either dont indicate that those resources are there or it is not the most natural collection

This makes it so that each resource is in its own file