### PR TITLE
Clean up tempalting and indenting in horizon chart

### DIFF
--- a/charts/horizon/templates/_helpers.tpl
+++ b/charts/horizon/templates/_helpers.tpl
@@ -25,9 +25,9 @@
 
 {{- define "core.config" -}}
 {{- if eq .Values.global.network "testnet" -}}
-{{- template "core.testnetConfig" }}
+{{- include "core.testnetConfig" . }}
 {{- else if eq .Values.global.network "pubnet" -}}
-{{- template "core.pubnetConfig" }}
+{{- include "core.pubnetConfig" . }}
 {{- else -}}
 {{- .Values.ingest.coreConfig }}
 {{- end -}}

--- a/charts/horizon/templates/core-configmap.yaml
+++ b/charts/horizon/templates/core-configmap.yaml
@@ -2,13 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "common.fullname" . }}-core
+  name: {{ include "common.fullname" . }}-core
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-core
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-core
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  stellar-core.cfg: |
-{{ include "core.config" . | indent 4 }}
+  stellar-core.cfg: | {{ include "core.config" . | nindent 4 }}

--- a/charts/horizon/templates/ingest-configmap.yaml
+++ b/charts/horizon/templates/ingest-configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "common.fullname" . }}-ingest-env
+  name: {{ include "common.fullname" . }}-ingest-env
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-ingest
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-ingest
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:

--- a/charts/horizon/templates/ingest-statefulset.yaml
+++ b/charts/horizon/templates/ingest-statefulset.yaml
@@ -3,42 +3,40 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "common.fullname" . }}-ingest
+  name: {{ include "common.fullname" . }}-ingest
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-ingest
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-ingest
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.ingest.replicaCount }}
-  serviceName: {{ template "common.fullname" . }}-ingest
+  serviceName: {{ include "common.fullname" . }}-ingest
   selector:
     matchLabels:
-      app: {{ template "common.fullname" . }}-ingest
+      app: {{ include "common.fullname" . }}-ingest
   template:
     metadata:
       labels:
-        app: {{ template "common.fullname" . }}-ingest
+        app: {{ include "common.fullname" . }}-ingest
         release: {{ .Release.Name }}
         horizon_network: {{ .Values.global.network }}
-      {{- if .Values.ingest.labels }}
-      {{- range $key, $value := .Values.ingest.labels }}
+        {{- if .Values.ingest.labels }}
+        {{- range $key, $value := .Values.ingest.labels }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.ingest.annotations }}
       annotations:
-      {{- range $key, $value := .Values.ingest.annotations }}
+        {{- range $key, $value := .Values.ingest.annotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}
+        {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.ingest.serviceAccountName }}
       serviceAccountName: {{ .Values.ingest.serviceAccountName }}
-      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 6 }}
       {{- end }}
       containers:
       - name: horizon
@@ -61,7 +59,7 @@ spec:
         - secretRef:
             name: {{ .Values.ingest.existingSecret }}
         - configMapRef:
-            name: {{ template "common.fullname" . }}-ingest-env
+            name: {{ include "common.fullname" . }}-ingest-env
         readinessProbe:
           httpGet:
             port: {{ .Values.ingest.horizonConfig.port }}
@@ -69,15 +67,14 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         {{- if .Values.ingest.resources }}
-        resources:
-{{ toYaml .Values.ingest.resources | indent 10 }}
+        resources: {{ toYaml .Values.ingest.resources | nindent 10 }}
         {{- end }}
         volumeMounts:
         - mountPath: /config
           name: core-config
         {{- if .Values.ingest.persistence.enabled }}
         - mountPath: /var/lib/stellar
-          name: {{ template "common.fullname" . }}-ingest-var-lib-stellar
+          name: {{ include "common.fullname" . }}-ingest-var-lib-stellar
         {{- end }}
       {{- if .Values.ingest.coreExporter.enabled }}
       - name: stellar-core-prometheus-exporter
@@ -87,18 +84,17 @@ spec:
         - containerPort: 9473
           name: metrics
         {{- if .Values.ingest.coreExporter.resources }}
-        resources:
-{{ toYaml .Values.ingest.coreExporter.resources | indent 10 }}
+        resources: {{ toYaml .Values.ingest.coreExporter.resources | nindent 10 }}
         {{- end }}
       {{- end }}
       volumes:
       - name: core-config
         configMap:
-          name: {{ template "common.fullname" . }}-core
+          name: {{ include "common.fullname" . }}-core
   {{- if .Values.ingest.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ template "common.fullname" . }}-ingest-var-lib-stellar
+      name: {{ include "common.fullname" . }}-ingest-var-lib-stellar
     spec:
       accessModes: ["ReadWriteOnce"]
       storageClassName: {{ .Values.ingest.persistence.storageClass }}
@@ -110,11 +106,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.fullname" . }}-ingest-core
+  name: {{ include "common.fullname" . }}-ingest-core
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-ingest-core
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-ingest-core
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -124,16 +120,16 @@ spec:
       port: 11626
       targetPort: 11626
   selector:
-    app: {{ template "common.fullname" . }}-ingest
+    app: {{ include "common.fullname" . }}-ingest
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.fullname" . }}-ingest
+  name: {{ include "common.fullname" . }}-ingest
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-ingest
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-ingest
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -143,5 +139,5 @@ spec:
       port: 80
       targetPort: {{ .Values.ingest.horizonConfig.port }}
   selector:
-    app: {{ template "common.fullname" . }}-ingest
+    app: {{ include "common.fullname" . }}-ingest
 {{- end }}

--- a/charts/horizon/templates/ingress.yaml
+++ b/charts/horizon/templates/ingress.yaml
@@ -3,17 +3,17 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "common.fullname" . }}-ingest
+  name: {{ include "common.fullname" . }}-ingest
   namespace: {{ .Release.Namespace }}
   {{- if .Values.ingest.ingress.annotations }}
   annotations:
-  {{- range $key, $value := .Values.ingest.ingress.annotations }}
+    {{- range $key, $value := .Values.ingest.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- end }}
   {{- end }}
 spec:
   tls:
-  - secretName: {{ template "common.fullname" . }}-ingest-cert
+  - secretName: {{ include "common.fullname" . }}-ingest-cert
     hosts:
     - {{ .Values.ingest.ingress.host }}
   rules:
@@ -24,7 +24,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ template "common.fullname" . }}-ingest
+            name: {{ include "common.fullname" . }}-ingest
             port:
               number: 80
 {{- end }}
@@ -33,17 +33,17 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "common.fullname" . }}-web
+  name: {{ include "common.fullname" . }}-web
   namespace: {{ .Release.Namespace }}
   {{- if .Values.web.ingress.annotations }}
   annotations:
     {{- range $key, $value := .Values.web.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 spec:
   tls:
-  - secretName: {{ template "common.fullname" . }}-web-cert
+  - secretName: {{ include "common.fullname" . }}-web-cert
     hosts:
     - {{ .Values.web.ingress.host }}
   rules:
@@ -54,7 +54,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ template "common.fullname" . }}-web
+            name: {{ include "common.fullname" . }}-web
             port:
               number: 80
 {{- end }}

--- a/charts/horizon/templates/web-configmap.yaml
+++ b/charts/horizon/templates/web-configmap.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "common.fullname" . }}-web-env
+  name: {{ include "common.fullname" . }}-web-env
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-web
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-web
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
@@ -24,9 +24,9 @@ data:
   PER_HOUR_RATE_LIMIT: {{ .Values.web.horizonConfig.perHourRateLimit | quote}}
   PORT: {{ .Values.web.horizonConfig.port | quote}}
   SSE_UPDATE_FREQUENCY: {{ .Values.web.horizonConfig.sseUpdateFrequency | quote}}
-  {{ if .Values.web.horizonConfig.stellarCoreUrl -}}
+  {{- if .Values.web.horizonConfig.stellarCoreUrl -}}
   STELLAR_CORE_URL: {{ .Values.web.horizonConfig.stellarCoreUrl | quote}}
   {{- else }}
-  STELLAR_CORE_URL: http://{{ template "common.fullname" . }}-ingest-core:11626
+  STELLAR_CORE_URL: http://{{ include "common.fullname" . }}-ingest-core:11626
   {{- end }}
 {{- end }}

--- a/charts/horizon/templates/web-deployment.yaml
+++ b/charts/horizon/templates/web-deployment.yaml
@@ -3,42 +3,41 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "common.fullname" . }}-web
+  name: {{ include "common.fullname" . }}-web
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-web
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-web
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.web.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "common.fullname" . }}-web
+      app: {{ include "common.fullname" . }}-web
   template:
     metadata:
       labels:
-        app: {{ template "common.fullname" . }}-web
+        app: {{ include "common.fullname" . }}-web
         release: {{ .Release.Name }}
         horizon_network: {{ .Values.global.network }}
-      {{- if .Values.web.labels }}
+        {{- if .Values.web.labels }}
         {{- range $key, $value := .Values.web.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       {{- if .Values.web.annotations }}
       annotations:
         {{- range $key, $value := .Values.web.annotations }}
-          {{ $key }}: {{ $value | quote }}
-          {{- end }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.web.serviceAccountName }}
       serviceAccountName: {{ .Values.web.serviceAccountName }}
-      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 8 }}
-      {{- end }}      containers:
+      imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
+      containers:
       - name: horizon
         image: {{ include "common.horizonImage" . | quote }}
         {{- if .Values.web.cliArgs }}
@@ -57,7 +56,7 @@ spec:
         - secretRef:
             name: {{ .Values.web.existingSecret }}
         - configMapRef:
-            name: {{ template "common.fullname" . }}-web-env
+            name: {{ include "common.fullname" . }}-web-env
         readinessProbe:
           httpGet:
             port: {{ .Values.web.horizonConfig.port }}
@@ -65,18 +64,17 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         {{- if .Values.web.resources }}
-        resources:
-{{ toYaml .Values.web.resources | indent 10 }}
+        resources: {{ toYaml .Values.web.resources | nindent 10 }}
         {{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.fullname" . }}-web
+  name: {{ include "common.fullname" . }}-web
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "common.fullname" . }}-web
-    chart: {{ template "common.chart" . }}
+    app: {{ include "common.fullname" . }}-web
+    chart: {{ include "common.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -86,5 +84,5 @@ spec:
       port: 80
       targetPort: {{ .Values.web.horizonConfig.port }}
   selector:
-    app: {{ template "common.fullname" . }}-web
+    app: {{ include "common.fullname" . }}-web
 {{- end }}


### PR DESCRIPTION
This PR cleans up some templating and indentation in the horizon chart

- use helm native `include` that returns a string over the go template `template` function
- align the indentation of the templating functions to where the resource values will be
- remove unused if function for service account
- fix indentation to match other values