### PR TITLE
SDP 3.1.1: remove nginx.ingress.kubernetes.io/server-snippet annotation

### DIFF
--- a/charts/stellar-disbursement-platform/Chart.yaml
+++ b/charts/stellar-disbursement-platform/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stellar-disbursement-platform
 description: A Helm chart for the Stellar Disbursement Platform Backend (A.K.A. `sdp`)
-version: "3.1.0"
+version: "3.1.1"
 appVersion: "3.1.0"
 type: application
 maintainers:

--- a/charts/stellar-disbursement-platform/templates/04.1-ingress-sdp.yaml
+++ b/charts/stellar-disbursement-platform/templates/04.1-ingress-sdp.yaml
@@ -8,11 +8,6 @@ metadata:
     {{- include "sdp.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.sdp.ingress.annotations | nindent 4 }}
-    # This is a way to block the stellar.toml file from being served on the "sdp.domain":
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ /.well-known/stellar.toml {
-        return 404;
-      }
 spec:
   {{- if .Values.sdp.ingress.className }}
   ingressClassName: {{ .Values.sdp.ingress.className }}

--- a/charts/stellar-disbursement-platform/templates/04.2-ingress-ap.yaml
+++ b/charts/stellar-disbursement-platform/templates/04.2-ingress-ap.yaml
@@ -8,11 +8,6 @@ metadata:
     {{- include "sdp.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.anchorPlatform.ingress.annotations | nindent 4 }}
-    # This is a way to block the stellar.toml file from being served on the "sdp.domain":
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location ~ /.well-known/stellar.toml {
-        proxy_pass {{ include "sdp.ap.sepServiceAddress" . }};
-      }
 spec:
   {{- if .Values.anchorPlatform.ingress.className }}
   ingressClassName: {{ .Values.anchorPlatform.ingress.className }}


### PR DESCRIPTION
### What

Remove `nginx.ingress.kubernetes.io/server-snippet` annotation

### Why

[This snippet](https://github.com/stellar/stellar-disbursement-platform-backend/pull/5/files#diff-ee6d3e08fc06195d14f677988de28e706e50231a869f86bbd8aa3110edc3d816) was a way to expose only one toml file (the AP one) through the same ingress, since we were using only one ingress for both SDP and AP.

It doesn't make sense anymore and should be removed