### PR TITLE
horizon-ingest: offer choice between Deployment and Statefulset

### DIFF
--- a/charts/horizon/templates/ingest-statefulset.yaml
+++ b/charts/horizon/templates/ingest-statefulset.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingest.enabled }}
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "common.fullname" . }}-ingest
   namespace: {{ .Release.Namespace }}

--- a/charts/horizon/templates/ingest.yaml
+++ b/charts/horizon/templates/ingest.yaml
@@ -97,7 +97,7 @@ spec:
       - name: core-config
         configMap:
           name: {{ include "common.fullname" . }}-core
-  {{- if .Values.ingest.persistence.enabled }}
+  {{- if and (.Values.ingest.persistence.enabled) (not (.Values.useDeployment))}}
   volumeClaimTemplates:
   - metadata:
       name: {{ include "common.fullname" . }}-ingest-var-lib-stellar

--- a/charts/horizon/templates/ingest.yaml
+++ b/charts/horizon/templates/ingest.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingest.enabled }}
 ---
 apiVersion: apps/v1
+{{- if .Values.useDeployment }}
 kind: Deployment
+{{ else }}
+kind: StatefulSet
+{{- end }}
 metadata:
   name: {{ include "common.fullname" . }}-ingest
   namespace: {{ .Release.Namespace }}
@@ -12,7 +16,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.ingest.replicaCount }}
+  {{- if not (.Values.useDeployment) }}
   serviceName: {{ include "common.fullname" . }}-ingest
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "common.fullname" . }}-ingest

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -1,4 +1,10 @@
 global:
+  ## You can choose between a StatefulSet (default) or Deployment
+  ## Use a Deployment for a single pod in a non-critical (dev) environment
+  ## Otherwise, choose StatefulSet
+
+  # useDeployment: true
+
   ## Stellar network to use. When set to "testnet" or "pubnet" default
   ## recommended config will be used.
   ## When set to any other value you have to provide extra settings:


### PR DESCRIPTION
### What
horizon-ingest: offer a choice between Statefulset and Deployment

### Why
Deployment for single pods

### Testing before merge
I tested both options with `helm template` and verified they work  in `dev-eks`

### Validation after merge
the template is updated

### Issue addressed by this PR
https://github.com/stellar/ops/issues/3821