### PR TITLE
Add parallel pod management to core, horizon ingest and rpc charts

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.0.3
+version: 0.1.0
 appVersion: "19.12.0-1378.2109a168a.focal"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.core.replicaCount }}
+  podManagementPolicy: {{ .Values.core.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
   selector:
     matchLabels:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -72,6 +72,9 @@ core:
   ## For production use cases we recommend at least 2 replicas
   replicaCount: 1
 
+  ## Core pods do not need to be initialized in a specific order
+  podManagementPolicy: Parallel
+
   ## Uncomment to use custom service account
   # serviceAccountName: default
 

--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: horizon
-version: 0.0.7
+version: 0.1.0
 appVersion: "2.26.1"
 description: Stellar Horizon Helm Chart. This chart will deploy Stellar Horizon API server
 maintainers: 

--- a/charts/horizon/templates/ingest.yaml
+++ b/charts/horizon/templates/ingest.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   replicas: {{ .Values.ingest.replicaCount }}
   {{- if not (.Values.useDeployment) }}
+  podManagementPolicy: {{ .Values.ingest.podManagementPolicy }}
   serviceName: {{ include "common.fullname" . }}-ingest
   {{- end }}
   selector:

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -90,6 +90,9 @@ ingest:
   ## For production use cases we recommend at least 2 replicas
   replicaCount: 1
 
+  ## Horizon ingest pods do not need to be initialized in a specific order
+  podManagementPolicy: Parallel
+
   serviceAccountName: default
 
   ## Additional annotations or labels to add the Deployment template

--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.1.1
+version: 0.2.0
 appVersion: "0.9.3"
 description: Stellar Soroban RPC Helm Chart. This chart will deploy Stellar Soroban API server
 maintainers:

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -19,6 +19,7 @@ spec:
   # gauranteed to be running while the other one is upgraded and catching backup to network 
   # after restart
   replicas: 2
+  podManagementPolicy: {{ .Values.sorobanRpc.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
   selector:
     matchLabels:

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -89,6 +89,9 @@ sorobanRpc:
     storageClass: default
     size: 100G
 
+  ## Soroban RPC pods do not need to be initialized in a specific order
+  podManagementPolicy: Parallel
+
   ## Uncomment to use custom service account
   # serviceAccountName: default
 


### PR DESCRIPTION
The core, soroban rpc, and horizon ingest statefulsets do not require pods to come up in a specific order. Currently, the 1st pod in each of these statefulsets has to wait for the 0th pod to be ready in order for the 1st to initialize.

This PR adds a value in these helm charts with a default of `Parallel` allowing the 1st and 2nd and Nth pods to spin up concurrently

https://github.com/stellar/ops/issues/3861
https://github.com/stellar/ops/issues/3859
https://github.com/stellar/ops/issues/3858