### PR TITLE
core: improve handling of /var/lib/stellar

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.3.0
-appVersion: "25.1.2-3007.d25bb5cd4.jammy"
+version: 0.4.0
+appVersion: "25.2.0-3058.bb195c49d.jammy"
 maintainers:
   - name: Stellar Development Foundation
 sources:

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -62,10 +62,8 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: core-config
-        {{- if .Values.core.persistence.enabled }}
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
-        {{- end }}
       containers:
       - name: core
         image: {{ include "common.coreImage" . | quote }}
@@ -90,10 +88,8 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: core-config
-        {{- if .Values.core.persistence.enabled }}
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
-        {{- end }}
       {{- if (.Values.core.coreExporter).enabled }}
       - name: stellar-core-prometheus-exporter
         image: "{{ .Values.global.image.coreExporter.registry }}/{{ .Values.global.image.coreExporter.repository }}:{{ .Values.global.image.coreExporter.tag }}"
@@ -120,15 +116,17 @@ spec:
         volumeMounts:
         - mountPath: /etc/nginx/conf.d
           name: nginx-config
-        {{- if .Values.core.persistence.enabled }}
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
-        {{- end }}
       {{- end }}
       volumes:
       - name: core-config
         configMap:
           name: {{ template "common.fullname" . }}
+      {{- if not .Values.core.persistence.enabled }}
+      - name: {{ template "common.fullname" . }}-var-lib-stellar
+        emptyDir: {}
+      {{- end }}
       {{- if (.Values.core.historyProxy).enabled }}
       - name: nginx-config
         configMap:


### PR DESCRIPTION
This PR improves how /var/lib/stellar directory is handled. Currently if persistence is not enabled new-db runs in an empeheral container which means it doesn't have real effect. This change will use emptyDir if persistence is disabled which will allow core to start as normal.

As drive-by I also bumped core version number