### PR TITLE
Improve history archive handling in the core chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.4.0
+version: 0.5.0
 appVersion: "25.2.0-3058.bb195c49d.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -52,9 +52,6 @@ spec:
           - /config/stellar-core.cfg
           - --console
         imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
-        ports:
-        - containerPort: 11626
-          name: core
         {{- if (.Values.core).resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -158,10 +155,16 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: core
       port: 11626
       targetPort: 11626
+    {{- if (.Values.core.historyProxy).enabled }}
+    - name: http
+      port: 80
+      targetPort: 80
+    {{- end }}
   selector:
     app: {{ template "common.fullname" . }}

--- a/charts/core/templates/history-proxy.yaml
+++ b/charts/core/templates/history-proxy.yaml
@@ -31,6 +31,91 @@ data:
     }
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.fullname" . }}-history-router-nginx
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}-history
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  default.conf: |
+    server {
+      listen 80;
+      server_name _;
+      resolver kube-dns.kube-system.svc.cluster.local valid=10s;
+      resolver_timeout 5s;
+
+      location ~ ^/([0-9]+)(/.*)?$ {
+        set $pod_index $1;
+        set $pod_path $2;
+
+        if ($pod_path = "") {
+          set $pod_path "/";
+        }
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+
+        proxy_pass http://{{ template "common.fullname" . }}-$pod_index.{{ template "common.fullname" . }}.{{ .Release.Namespace | default "default" }}.svc.cluster.local:80$pod_path;
+      }
+
+      location / {
+        return 404;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "common.fullname" . }}-history
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}-history
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.core.historyProxy.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ template "common.fullname" . }}-history
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "common.fullname" . }}-history
+        release: {{ .Release.Name }}
+    spec:
+      {{- if (.Values.global).imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: history-router
+        image: "{{ .Values.global.image.nginx.registry }}/{{ .Values.global.image.nginx.repository }}:{{ .Values.global.image.nginx.tag }}"
+        imagePullPolicy: {{ .Values.global.image.nginx.pullPolicy }}
+        ports:
+        - containerPort: 80
+          name: http
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: nginx-router-config
+      volumes:
+      - name: nginx-router-config
+        configMap:
+          name: {{ template "common.fullname" . }}-history-router-nginx
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.fullname" . }}-history
@@ -49,7 +134,8 @@ spec:
       port: 80
       targetPort: 80
   selector:
-    app: {{ template "common.fullname" . }}
+    app: {{ template "common.fullname" . }}-history
+    release: {{ .Release.Name }}
 {{- if and (.Values.core.historyProxy.ingress.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -66,6 +152,9 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  {{- if (.Values.core.historyProxy.ingress).ingressClassName }}
+  ingressClassName: {{ .Values.core.historyProxy.ingress.ingressClassName }}
+  {{- end }}
   tls:
   - secretName: {{ template "common.fullname" . }}-history-cert
     hosts:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -95,6 +95,7 @@ core:
   # will make the chart deplo reverse proxy nginx container
   historyProxy:
     enabled: false
+    replicaCount: 1
 
     ## Path to serve over http
     # localPath: /var/lib/stellar/local_archive
@@ -110,9 +111,9 @@ core:
     ingress:
       enabled: false
       host: history-proxy.example.com
+      # ingressClassName: nginx
       ## Extra annotations to add to the Ingress object
       #annotations:
-      #  kubernetes.io/ingress.class: "public"
       #  cert-manager.io/cluster-issuer: "default"
       ## Extra labels to add to the Ingress object
       #labels:


### PR DESCRIPTION
This PR improves how we handle history archives
* switch service to headless and enable publishing of NotReadyNodes. This is needed because history archive should be served even if the node is catching up
* expose port 80 (history archive) if archive is enabled
* add ingressClassName to the history Ingress
* add new "router" Deployment and Service. This is needed for exposing individual archives.
* as a drive-by fix I also removed duplicated port definition in the init container as it was causing errors