### PR TITLE
Improve initialization in the core chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.5.0
+version: 0.6.0
 appVersion: "25.2.0-3058.bb195c49d.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-init-scripts-cm.yaml
+++ b/charts/core/templates/core-init-scripts-cm.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.fullname" . }}-init-scripts
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  init.sh: |
+{{ .Values.core.initScript | indent 4 }}

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -44,13 +44,9 @@ spec:
 {{ toYaml .Values.global.imagePullSecrets | indent 8 }}
       {{- end }}
       initContainers:
-      - name: core-new-db
+      - name: core-init
         image: {{ include "common.coreImage" . | quote }}
-        args:
-          - new-db
-          - --conf
-          - /config/stellar-core.cfg
-          - --console
+        command: ["/bin/bash", "/init-scripts/init.sh"]
         imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
         {{- if (.Values.core).resources }}
         resources:
@@ -61,6 +57,8 @@ spec:
           name: core-config
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
+        - mountPath: /init-scripts
+          name: init-scripts
       containers:
       - name: core
         image: {{ include "common.coreImage" . | quote }}
@@ -120,6 +118,10 @@ spec:
       - name: core-config
         configMap:
           name: {{ template "common.fullname" . }}
+      - name: init-scripts
+        configMap:
+          name: {{ template "common.fullname" . }}-init-scripts
+          defaultMode: 0755
       {{- if not .Values.core.persistence.enabled }}
       - name: {{ template "common.fullname" . }}-var-lib-stellar
         emptyDir: {}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -62,6 +62,20 @@ global:
 core:
   ## See global.image.core for image settings
 
+  ## Init script executed before core starts.
+  initScript: |
+    #!/bin/bash
+    set -ex
+
+    # Try to run upgrade-db to install latest schema. If schema is not present yet
+    # the command will fail. In such case we run new-db to create schema from scratch.
+    stellar-core upgrade-db --conf /config/stellar-core.cfg --console || \
+    stellar-core new-db --conf /config/stellar-core.cfg --console
+
+    ## Below can be used to initialize history archive in an idempotent way
+    # ls -l /var/lib/stellar/local_archive/.well-known/stellar-history.json || \
+    # stellar-core new-hist local --conf /config/stellar-core.cfg --console
+
   ## List of extra CLI arguments to provide to the stellar-core binary
   extraCliArgs: []
 


### PR DESCRIPTION
This pull request will improve the way we initialize core. After the change new-db will only run if no schema is present. This is a slight behaviour change but it's safer than the existing one. Other that being safer the new version is a drop-in replacement that doesn't require operators to take any action.
The new method also allows operators to customize how core is initialized and also allows for handling of history archives.