### PR TITLE
Add support for controlling PVC retention policy in 2 charts

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.6.1
+version: 0.7.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.core.replicaCount }}
   podManagementPolicy: {{ .Values.core.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
-  {{- if .Values.core.persistence.persistentVolumeClaimRetentionPolicy }}
+  {{- if and .Values.core.persistence.enabled .Values.core.persistence.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
     {{- toYaml .Values.core.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -15,6 +15,10 @@ spec:
   replicas: {{ .Values.core.replicaCount }}
   podManagementPolicy: {{ .Values.core.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
+  {{- if .Values.core.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.core.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "common.fullname" . }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -104,6 +104,11 @@ core:
     enabled: false
     storageClass: default
     size: 100G
+    ## Persistent volume claim retention policy for the StatefulSet.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Retain
+    #   whenScaled: Retain
 
   ## Validators need to publish history archives. historyProxy section
   # will make the chart deplo reverse proxy nginx container

--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.4.1
+version: 0.5.0
 appVersion: "26.0.0"
 description: Stellar RPC Helm Chart. This chart will deploy Stellar RPC server
 maintainers:

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -21,7 +21,7 @@ spec:
   replicas: {{ .Values.sorobanRpc.replicaCount | default 2 | int }}
   podManagementPolicy: {{ .Values.sorobanRpc.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
-  {{- if .Values.sorobanRpc.persistence.persistentVolumeClaimRetentionPolicy }}
+  {{- if and .Values.sorobanRpc.persistence.enabled .Values.sorobanRpc.persistence.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
     {{- toYaml .Values.sorobanRpc.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-sts.yaml
@@ -21,6 +21,10 @@ spec:
   replicas: {{ .Values.sorobanRpc.replicaCount | default 2 | int }}
   podManagementPolicy: {{ .Values.sorobanRpc.podManagementPolicy }}
   serviceName: {{ template "common.fullname" . }}
+  {{- if .Values.sorobanRpc.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.sorobanRpc.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "common.fullname" . }}

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -95,6 +95,11 @@ sorobanRpc:
     enabled: false
     storageClass: default
     size: 100G
+    ## Persistent volume claim retention policy for the StatefulSet.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Retain
+    #   whenScaled: Retain
 
   ## Soroban RPC pods do not need to be initialized in a specific order
   podManagementPolicy: Parallel


### PR DESCRIPTION
This PR adds support for controlling PVC retention policy using persistentVolumeClaimRetentionPolicy.
Default behaviour doesn't change so this PR is backwards compabitle.