### PR TITLE
core: add support for extra volumes and secret

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.7.0
+version: 0.8.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -63,6 +63,14 @@ spec:
           name: {{ template "common.fullname" . }}-var-lib-stellar
         - mountPath: /init-scripts
           name: init-scripts
+        {{- if (.Values.core).existingSecret }}
+        - mountPath: {{ .Values.core.existingSecret.mountPath | default "/secret" }}
+          name: existing-secret
+          readOnly: true
+        {{- end }}
+        {{- if (.Values.core).extraVolumeMounts }}
+{{ toYaml .Values.core.extraVolumeMounts | indent 8 }}
+        {{- end }}
       containers:
       - name: core
         image: {{ include "common.coreImage" . | quote }}
@@ -91,6 +99,14 @@ spec:
           name: core-config
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
+        {{- if (.Values.core).existingSecret }}
+        - mountPath: {{ .Values.core.existingSecret.mountPath | default "/secret" }}
+          name: existing-secret
+          readOnly: true
+        {{- end }}
+        {{- if (.Values.core).extraVolumeMounts }}
+{{ toYaml .Values.core.extraVolumeMounts | indent 8 }}
+        {{- end }}
       {{- if (.Values.core.coreExporter).enabled }}
       - name: stellar-core-prometheus-exporter
         image: "{{ .Values.global.image.coreExporter.registry }}/{{ .Values.global.image.coreExporter.repository }}:{{ .Values.global.image.coreExporter.tag }}"
@@ -136,6 +152,14 @@ spec:
       - name: nginx-config
         configMap:
           name: {{ template "common.fullname" . }}-nginx
+      {{- end }}
+      {{- if (.Values.core).existingSecret }}
+      - name: existing-secret
+        secret:
+          secretName: {{ .Values.core.existingSecret.name }}
+      {{- end }}
+      {{- if (.Values.core).extraVolumes }}
+{{ toYaml .Values.core.extraVolumes | indent 6 }}
       {{- end }}
       affinity: {{- toYaml .Values.core.affinity | nindent 8 }}
   {{- if .Values.core.persistence.enabled }}

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -63,8 +63,8 @@ spec:
           name: {{ template "common.fullname" . }}-var-lib-stellar
         - mountPath: /init-scripts
           name: init-scripts
-        {{- if (.Values.core).existingSecret }}
-        - mountPath: {{ .Values.core.existingSecret.mountPath | default "/secret" }}
+        {{- if (.Values.core).existingSecretName }}
+        - mountPath: /secret
           name: existing-secret
           readOnly: true
         {{- end }}
@@ -99,8 +99,8 @@ spec:
           name: core-config
         - mountPath: /var/lib/stellar
           name: {{ template "common.fullname" . }}-var-lib-stellar
-        {{- if (.Values.core).existingSecret }}
-        - mountPath: {{ .Values.core.existingSecret.mountPath | default "/secret" }}
+        {{- if (.Values.core).existingSecretName }}
+        - mountPath: /secret
           name: existing-secret
           readOnly: true
         {{- end }}
@@ -153,10 +153,10 @@ spec:
         configMap:
           name: {{ template "common.fullname" . }}-nginx
       {{- end }}
-      {{- if (.Values.core).existingSecret }}
+      {{- if (.Values.core).existingSecretName }}
       - name: existing-secret
         secret:
-          secretName: {{ .Values.core.existingSecret.name }}
+          secretName: {{ .Values.core.existingSecretName }}
       {{- end }}
       {{- if (.Values.core).extraVolumes }}
 {{ toYaml .Values.core.extraVolumes | indent 6 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -92,11 +92,10 @@ core:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
-  ## Mount a pre-existing Kubernetes secret into the core containers.
-  ## Useful for providing sensitive config such as validator seed.
-  # existingSecret:
-  #   name: my-core-secret
-  #   mountPath: /secret
+  ## Name of a pre-existing Kubernetes secret that will be mounted.
+  ## Useful for providing sensitive config such as validator seed or
+  ## database URL
+  # existingSecretName: my-core-secret
 
   ## Extra volumes to add to the pod.
   # extraVolumes:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -92,6 +92,23 @@ core:
   ## Uncomment to use custom service account
   # serviceAccountName: default
 
+  ## Mount a pre-existing Kubernetes secret into the core containers.
+  ## Useful for providing sensitive config such as validator seed.
+  # existingSecret:
+  #   name: my-core-secret
+  #   mountPath: /secret
+
+  ## Extra volumes to add to the pod.
+  # extraVolumes:
+  #   - name: my-extra-volume
+  #     emptyDir: {}
+
+  ## Extra volume mounts for the init and core containers only.
+  ## Not mounted in the prometheus exporter or history proxy containers.
+  # extraVolumeMounts:
+  #   - name: my-extra-volume
+  #     mountPath: /extra
+
   ## Additional annotations or labels to add the Deployment template
   # annotations:
   #   prometheus.io/scrape: "true"


### PR DESCRIPTION
### What

This PR will allow operators to mount extra secret and volumes in the core and core-init containers.

### Why

To allow us to run multiple validators from one StatefulSet we need a way for each pod to use different seed.
Having capability to use pre-existing secret and memory-backed empty dir will allow operators to prepare seeds in the init continainer and consume them in the core container.