### PR TITLE
core: allow for core args to be overriden

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.8.0
+version: 0.9.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -74,6 +74,10 @@ spec:
       containers:
       - name: core
         image: {{ include "common.coreImage" . | quote }}
+        {{- if (.Values.core).args }}
+        args:
+          {{- toYaml .Values.core.args | nindent 10 }}
+        {{- else }}
         args:
           - run
           - --conf
@@ -83,6 +87,7 @@ spec:
           {{- range $flag := .Values.core.extraCliArgs }}
           - {{ $flag | quote }}
           {{- end }}
+        {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.core.pullPolicy }}
         ports:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -76,7 +76,16 @@ core:
     # ls -l /var/lib/stellar/local_archive/.well-known/stellar-history.json || \
     # stellar-core new-hist local --conf /config/stellar-core.cfg --console
 
-  ## List of extra CLI arguments to provide to the stellar-core binary
+  ## Override the container args. When set, replaces the default args entirely.
+  ## Default args are: ["run", "--conf", "/config/stellar-core.cfg", "--console"]
+  # args:
+  #   - run
+  #   - --conf
+  #   - /config/stellar-core.cfg
+  #   - --console
+
+  ## List of extra CLI arguments to append to the default args.
+  ## Ignored when args is overridden above.
   extraCliArgs: []
 
   ## Required when global.network is set to non-standard value


### PR DESCRIPTION
This PR extends the core chart to allow operators to override default core args.
Default behaviour doesn't change so the change is
backwards compatible.