### PR TITLE
Add gateway API support to the horizon chart

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: horizon
-version: 0.4.0
+version: 0.5.0
 appVersion: "26.0.0"
 description: Stellar Horizon Helm Chart. This chart will deploy Stellar Horizon API server
 maintainers: 

--- a/charts/horizon/templates/gateway.yaml
+++ b/charts/horizon/templates/gateway.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.ingest.enabled .Values.ingest.httpRoute.enabled .Values.ingest.httpRoute.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.ingest.httpRoute.gateway.name | default (printf "%s-ingest-gateway" (include "common.fullname" .)) }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.ingest.httpRoute.gateway.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingest.httpRoute.gateway.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.ingest.httpRoute.gateway.labels }}
+  labels:
+    {{- range $key, $value := .Values.ingest.httpRoute.gateway.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "ingest.httpRoute.gateway.gatewayClassName is required when gateway is enabled" .Values.ingest.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.ingest.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- if and .Values.web.enabled .Values.web.httpRoute.enabled .Values.web.httpRoute.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.web.httpRoute.gateway.name | default (printf "%s-web-gateway" (include "common.fullname" .)) }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.web.httpRoute.gateway.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.web.httpRoute.gateway.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.web.httpRoute.gateway.labels }}
+  labels:
+    {{- range $key, $value := .Values.web.httpRoute.gateway.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "web.httpRoute.gateway.gatewayClassName is required when gateway is enabled" .Values.web.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.web.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/horizon/templates/ingest-httproute.yaml
+++ b/charts/horizon/templates/ingest-httproute.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.ingest.httpRoute.gateway.enabled }}
+    - name: {{ .Values.ingest.httpRoute.gateway.name | default (printf "%s-ingest-gateway" (include "common.fullname" .)) }}
+    {{- else }}
     {{- range .Values.ingest.httpRoute.parentRefs }}
     - name: {{ .name }}
       {{- if .namespace }}
@@ -27,6 +30,7 @@ spec:
       {{- if .sectionName }}
       sectionName: {{ .sectionName }}
       {{- end }}
+    {{- end }}
     {{- end }}
   {{- if .Values.ingest.httpRoute.hostnames }}
   hostnames:

--- a/charts/horizon/templates/ingest-httproute.yaml
+++ b/charts/horizon/templates/ingest-httproute.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.ingest.enabled .Values.ingest.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "common.fullname" . }}-ingest
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.ingest.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingest.httpRoute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.ingest.httpRoute.labels }}
+  labels:
+    {{- range $key, $value := .Values.ingest.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.ingest.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.ingest.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.ingest.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "common.fullname" . }}-ingest
+          port: 8000
+{{- end }}

--- a/charts/horizon/templates/web-httproute.yaml
+++ b/charts/horizon/templates/web-httproute.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.web.enabled .Values.web.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "common.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.web.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.web.httpRoute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.web.httpRoute.labels }}
+  labels:
+    {{- range $key, $value := .Values.web.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.web.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.web.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.web.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "common.fullname" . }}-web
+          port: 8000
+{{- end }}

--- a/charts/horizon/templates/web-httproute.yaml
+++ b/charts/horizon/templates/web-httproute.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.web.httpRoute.gateway.enabled }}
+    - name: {{ .Values.web.httpRoute.gateway.name | default (printf "%s-web-gateway" (include "common.fullname" .)) }}
+    {{- else }}
     {{- range .Values.web.httpRoute.parentRefs }}
     - name: {{ .name }}
       {{- if .namespace }}
@@ -27,6 +30,7 @@ spec:
       {{- if .sectionName }}
       sectionName: {{ .sectionName }}
       {{- end }}
+    {{- end }}
     {{- end }}
   {{- if .Values.web.httpRoute.hostnames }}
   hostnames:

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -176,6 +176,43 @@ ingest:
   #       topologyKey: kubernetes.io/hostname
   affinity: {}
 
+  ## Controls whether ingesting instances are exposed via Gateway API HTTPRoute
+  httpRoute:
+    enabled: false
+    ## Reference to an existing Gateway (or the one created by this chart)
+    parentRefs:
+      - name: horizon-gateway
+        namespace: ""  # defaults to release namespace
+        sectionName: ""
+    hostnames:
+      - horizon-ingest.example.com
+    ## Extra annotations to add to the HTTPRoute object
+    annotations: {}
+    ## Extra labels to add to the HTTPRoute object
+    labels: {}
+    ## Optional Gateway resource created in the same namespace
+    gateway:
+      enabled: false
+      ## Gateway class name (e.g. "istio", "traefik")
+      gatewayClassName: ""
+      ## Gateway name override. Defaults to <fullname>-ingest-gateway
+      name: ""
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+        # - name: https
+        #   protocol: HTTPS
+        #   port: 443
+        #   tls:
+        #     mode: Terminate
+        #     certificateRefs:
+        #       - name: horizon-tls-cert
+      ## Extra annotations to add to the Gateway object
+      annotations: {}
+      ## Extra labels to add to the Gateway object
+      labels: {}
+
   ## Example podDisruptionBudget
   # podDisruptionBudget:
   #   minAvailable: 1
@@ -251,6 +288,43 @@ web:
   #           app: stellar-horizon-web
   #       topologyKey: kubernetes.io/hostname
   affinity: {}
+
+  ## Controls whether web instances are exposed via Gateway API HTTPRoute
+  httpRoute:
+    enabled: false
+    ## Reference to an existing Gateway (or the one created by this chart)
+    parentRefs:
+      - name: horizon-gateway
+        namespace: ""  # defaults to release namespace
+        sectionName: ""
+    hostnames:
+      - horizon-web.example.com
+    ## Extra annotations to add to the HTTPRoute object
+    annotations: {}
+    ## Extra labels to add to the HTTPRoute object
+    labels: {}
+    ## Optional Gateway resource created in the same namespace
+    gateway:
+      enabled: false
+      ## Gateway class name (e.g. "istio", "traefik")
+      gatewayClassName: ""
+      ## Gateway name override. Defaults to <fullname>-web-gateway
+      name: ""
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+        # - name: https
+        #   protocol: HTTPS
+        #   port: 443
+        #   tls:
+        #     mode: Terminate
+        #     certificateRefs:
+        #       - name: horizon-tls-cert
+      ## Extra annotations to add to the Gateway object
+      annotations: {}
+      ## Extra labels to add to the Gateway object
+      labels: {}
 
   ## Example podDisruptionBudget
   # podDisruptionBudget:

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -179,7 +179,8 @@ ingest:
   ## Controls whether ingesting instances are exposed via Gateway API HTTPRoute
   httpRoute:
     enabled: false
-    ## Reference to an existing Gateway (or the one created by this chart)
+    ## Reference to an existing external Gateway. Only used when gateway.enabled=false.
+    ## When gateway.enabled=true, parentRefs are auto-computed from the created Gateway.
     parentRefs:
       - name: horizon-gateway
         namespace: ""  # defaults to release namespace
@@ -292,7 +293,8 @@ web:
   ## Controls whether web instances are exposed via Gateway API HTTPRoute
   httpRoute:
     enabled: false
-    ## Reference to an existing Gateway (or the one created by this chart)
+    ## Reference to an existing external Gateway. Only used when gateway.enabled=false.
+    ## When gateway.enabled=true, parentRefs are auto-computed from the created Gateway.
     parentRefs:
       - name: horizon-gateway
         namespace: ""  # defaults to release namespace


### PR DESCRIPTION
This PR adds Gateway API support to the horizon chart. The support is backwards compabitle as default behaviour does not change.