### PR TITLE
Add Gateway API support to the core chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.9.0
+version: 0.10.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/history-proxy-gateway.yaml
+++ b/charts/core/templates/history-proxy-gateway.yaml
@@ -1,0 +1,39 @@
+{{- if and (.Values.core.historyProxy.enabled) (.Values.core.historyProxy.httpRoute.enabled) (.Values.core.historyProxy.httpRoute.gateway.enabled) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.core.historyProxy.httpRoute.gateway.name | default (printf "%s-history-gateway" (include "common.fullname" .)) }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.core.historyProxy.httpRoute.gateway.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.core.historyProxy.httpRoute.gateway.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.core.historyProxy.httpRoute.gateway.labels }}
+  labels:
+    {{- range $key, $value := .Values.core.historyProxy.httpRoute.gateway.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "core.historyProxy.httpRoute.gateway.gatewayClassName is required when gateway is enabled" .Values.core.historyProxy.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.core.historyProxy.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/core/templates/history-proxy-httproute.yaml
+++ b/charts/core/templates/history-proxy-httproute.yaml
@@ -1,0 +1,45 @@
+{{- if and (.Values.core.historyProxy.enabled) (.Values.core.historyProxy.httpRoute.enabled) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "common.fullname" . }}-history
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.core.historyProxy.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.core.historyProxy.httpRoute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.core.historyProxy.httpRoute.labels }}
+  labels:
+    {{- range $key, $value := .Values.core.historyProxy.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.core.historyProxy.httpRoute.gateway.enabled }}
+    - name: {{ .Values.core.historyProxy.httpRoute.gateway.name | default (printf "%s-history-gateway" (include "common.fullname" .)) }}
+    {{- else }}
+    {{- range .Values.core.historyProxy.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.core.historyProxy.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.core.historyProxy.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "common.fullname" . }}-history
+          port: 80
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -163,6 +163,44 @@ core:
       #labels:
       #  mylabel: myvalue
 
+    ## Controls whether history proxy is exposed via Gateway API HTTPRoute
+    httpRoute:
+      enabled: false
+      ## Reference to an existing external Gateway. Only used when gateway.enabled=false.
+      ## When gateway.enabled=true, parentRefs are auto-computed from the created Gateway.
+      parentRefs:
+        - name: core-gateway
+          namespace: ""  # defaults to release namespace
+          sectionName: ""
+      hostnames:
+        - history.example.com
+      ## Extra annotations to add to the HTTPRoute object
+      annotations: {}
+      ## Extra labels to add to the HTTPRoute object
+      labels: {}
+      ## Optional Gateway resource created in the same namespace
+      gateway:
+        enabled: false
+        ## Gateway class name (e.g. "istio", "traefik")
+        gatewayClassName: ""
+        ## Gateway name override. Defaults to <fullname>-history-gateway
+        name: ""
+        listeners:
+          - name: http
+            protocol: HTTP
+            port: 80
+          # - name: https
+          #   protocol: HTTPS
+          #   port: 443
+          #   tls:
+          #     mode: Terminate
+          #     certificateRefs:
+          #       - name: history-tls-cert
+        ## Extra annotations to add to the Gateway object
+        annotations: {}
+        ## Extra labels to add to the Gateway object
+        labels: {}
+
   ## Uncomment to set resource limits
   #resources:
   #  limits:


### PR DESCRIPTION
This PR adds Gateway API support to the core chart. The support is backwards compabitle as default behaviour does not change.