### PR TITLE
Add default readinessProbe to the core chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.10.2
+version: 0.11.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-sts.yaml
+++ b/charts/core/templates/core-sts.yaml
@@ -99,6 +99,10 @@ spec:
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
         {{- end }}
+        {{- with .Values.core.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /config
           name: core-config

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -210,6 +210,17 @@ core:
   #    cpu: 250m
   #    memory: 2Gi
 
+  ## Readiness probe for the core container.
+  ## By default, checks that the core node reports as "Synced!" via its /info endpoint.
+  ## Set to {} to disable the probe.
+  readinessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          curl http://localhost:11626/info | grep '"state" : "Synced!"'
+
   coreExporter:
     ## Common prometheus config examples do not allow it to scrape 2 ports
     ## If you'd like to scrape both horizon and core metrics example


### PR DESCRIPTION
### What

This PR adds basic readinessProbe to the core chart. There is a default behaviour change. Old behaviour can be restored by setting empty value of the `readinessProbe` key.

### Why

This will allow k8s to better manage core pods