### PR TITLE
Refactor CNPG support in the horizon chart

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: horizon
-version: 0.6.0
-appVersion: "26.0.0"
+version: 0.7.0
+appVersion: "27.0.0"
 description: Stellar Horizon Helm Chart. This chart will deploy Stellar Horizon API server
 maintainers: 
   - name: Stellar Development Foundation

--- a/charts/horizon/README.md
+++ b/charts/horizon/README.md
@@ -24,8 +24,9 @@ helm install myhorizon stellar/horizon \
 
 Notes:
 - CloudNativePG operator and CRDs must already be installed in the cluster.
-- `cnpg.auth.password` is required whenever `cnpg.enabled=true` (it is used to bootstrap the CNPG cluster user and to generate the `DATABASE_URL` secret when \`ingest.existingSecret\` / \`web.existingSecret\` are not set).
+- `cnpg.auth.password` is required whenever `cnpg.enabled=true` (it is used to bootstrap the CNPG cluster user and to generate the `DATABASE_URL` secret when `ingest.existingSecret` / `web.existingSecret` are not set).
 - You can still use external DB credentials by setting `ingest.existingSecret` and/or `web.existingSecret`.
+- Any field on the CNPG `Cluster.spec` (instances, storage, `enablePDB`, monitoring, backup, etc.) can be set under `cnpg.cluster.spec`. See `values.yaml` for details.
 
 Add SDF helm repo to your system:
 ```

--- a/charts/horizon/templates/_cnpg.tpl
+++ b/charts/horizon/templates/_cnpg.tpl
@@ -1,0 +1,58 @@
+{{/*
+  Build the CNPG Cluster .spec.
+
+  The primary source of truth is .Values.cnpg.cluster.spec, which is a
+  free-form pass-through mapping any field on the CNPG Cluster CRD (e.g.
+  instances, storage, enablePDB, monitoring, backup, resources, affinity,
+  postgresql, primaryUpdateStrategy, ...).
+
+  Precedence (low -> high, deep merge):
+    1. Built-in defaults seeded in this helper (instances: 1, storage.size: 50Gi).
+    2. Legacy shortcut keys under .Values.cnpg.cluster (deprecated, prefer
+       .Values.cnpg.cluster.spec):
+         - instances
+         - imageName
+         - storage.size
+         - storage.storageClass
+    3. .Values.cnpg.cluster.spec (wins on conflict).
+
+  `bootstrap` is always injected from .Values.cnpg.auth and the chart-
+  managed app secret; it can still be overridden via
+  .Values.cnpg.cluster.spec.bootstrap.
+
+  Returns the spec as YAML (without indentation); callers should pipe it
+  through `nindent` at the desired indent level.
+
+  Usage:
+    spec:
+      {{- include "horizon.cnpgClusterSpec" . | nindent 2 }}
+*/}}
+{{- define "horizon.cnpgClusterSpec" -}}
+{{- /* Built-in defaults (lowest priority; overridable by legacy shortcuts or by cnpg.cluster.spec) */ -}}
+{{- $shortcuts := dict
+    "instances" 1
+    "storage"   (dict "size" "50Gi")
+-}}
+{{- /* Legacy shortcuts (deprecated, prefer cnpg.cluster.spec) */ -}}
+{{- if hasKey .Values.cnpg.cluster "instances" -}}
+  {{- $_ := set $shortcuts "instances" .Values.cnpg.cluster.instances -}}
+{{- end -}}
+{{- if .Values.cnpg.cluster.imageName -}}
+  {{- $_ := set $shortcuts "imageName" .Values.cnpg.cluster.imageName -}}
+{{- end -}}
+{{- $legacyStorage := default (dict) .Values.cnpg.cluster.storage -}}
+{{- if $legacyStorage.size -}}
+  {{- $_ := set (index $shortcuts "storage") "size" $legacyStorage.size -}}
+{{- end -}}
+{{- if $legacyStorage.storageClass -}}
+  {{- $_ := set (index $shortcuts "storage") "storageClass" $legacyStorage.storageClass -}}
+{{- end -}}
+{{- /* Always-injected bootstrap (still overridable via cnpg.cluster.spec.bootstrap) */ -}}
+{{- $_ := set $shortcuts "bootstrap" (dict "initdb" (dict
+    "database" (required "cnpg.auth.database is required when cnpg.enabled=true" .Values.cnpg.auth.database)
+    "owner"    (required "cnpg.auth.username is required when cnpg.enabled=true" .Values.cnpg.auth.username)
+    "secret"   (dict "name" (include "horizon.cnpgAppSecretName" .)))) -}}
+{{- $extra := default (dict) .Values.cnpg.cluster.spec -}}
+{{- $spec := mergeOverwrite $shortcuts (deepCopy $extra) -}}
+{{- toYaml $spec }}
+{{- end -}}

--- a/charts/horizon/templates/cnpg-cluster.yaml
+++ b/charts/horizon/templates/cnpg-cluster.yaml
@@ -10,19 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  instances: {{ .Values.cnpg.cluster.instances }}
-  storage:
-    size: {{ .Values.cnpg.cluster.storage.size | quote }}
-    {{- if .Values.cnpg.cluster.storage.storageClass }}
-    storageClass: {{ .Values.cnpg.cluster.storage.storageClass | quote }}
-    {{- end }}
-  {{- if .Values.cnpg.cluster.imageName }}
-  imageName: {{ .Values.cnpg.cluster.imageName | quote }}
-  {{- end }}
-  bootstrap:
-    initdb:
-      database: {{ required "cnpg.auth.database is required when cnpg.enabled=true" .Values.cnpg.auth.database | quote }}
-      owner: {{ required "cnpg.auth.username is required when cnpg.enabled=true" .Values.cnpg.auth.username | quote }}
-      secret:
-        name: {{ include "horizon.cnpgAppSecretName" . }}
+  {{- include "horizon.cnpgClusterSpec" . | nindent 2 }}
 {{- end }}

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -69,21 +69,20 @@ cnpg:
     ## Free-form pass-through for the CNPG Cluster spec. Set any field
     ## supported by the CNPG Cluster CRD here, e.g.:
     ##
-    ##   spec:
-    ##     instances: 3
-    ##     storage:
-    ##       size: 200Gi
-    ##       storageClass: fast-ssd
-    ##     enablePDB: true
-    ##     monitoring:
-    ##       enablePodMonitor: true
-    ##     postgresql:
-    ##       parameters:
-    ##         max_connections: "200"
-    ##     resources:
-    ##       requests:
-    ##         cpu: 500m
-    ##         memory: 1Gi
+    ##   instances: 3
+    ##   storage:
+    ##     size: 200Gi
+    ##     storageClass: fast-ssd
+    ##   enablePDB: true
+    ##   monitoring:
+    ##     enablePodMonitor: true
+    ##   postgresql:
+    ##     parameters:
+    ##       max_connections: "200"
+    ##   resources:
+    ##     requests:
+    ##       cpu: 500m
+    ##       memory: 1Gi
     ##
     ## Notes:
     ## - Fields are passed through unchanged; validation is done by the CNPG

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -58,18 +58,43 @@ global:
 ## for ingest/web unless ingest.existingSecret / web.existingSecret are set.
 cnpg:
   enabled: false
-  cluster:
-    ## Optional cluster name override. Defaults to <release>-horizon-db
-    name: ""
-    instances: 1
-    imageName: ""
-    storage:
-      size: 50Gi
-      storageClass: ""
   auth:
     username: horizon
     password: ""
     database: horizon
+  cluster:
+    ## Optional cluster name override. Defaults to <release>-horizon-db
+    name: ""
+    spec: {}
+    ## Free-form pass-through for the CNPG Cluster spec. Set any field
+    ## supported by the CNPG Cluster CRD here, e.g.:
+    ##
+    ##   spec:
+    ##     instances: 3
+    ##     storage:
+    ##       size: 200Gi
+    ##       storageClass: fast-ssd
+    ##     enablePDB: true
+    ##     monitoring:
+    ##       enablePodMonitor: true
+    ##     postgresql:
+    ##       parameters:
+    ##         max_connections: "200"
+    ##     resources:
+    ##       requests:
+    ##         cpu: 500m
+    ##         memory: 1Gi
+    ##
+    ## Notes:
+    ## - Fields are passed through unchanged; validation is done by the CNPG
+    ##   webhook, not by this chart.
+    ## - `bootstrap` is auto-populated from `cnpg.auth.*` and the chart-
+    ##   managed app secret. Override it only if you also set
+    ##   ingest.existingSecret / web.existingSecret to bring your own DB URL.
+    ## - Built-in defaults are `instances: 1` and `storage.size: 50Gi`;
+    ##   anything set here (or via the legacy `cnpg.cluster.storage.*` /
+    ##   `cnpg.cluster.instances` / `cnpg.cluster.imageName` shortcuts)
+    ##   overrides them.
 
 ingest:
   ## See global.image.horizon for image settings


### PR DESCRIPTION
This PR will allow users to have more control over CNPG that can be deployed using the horizon chart.
For backwards compatibility I added code that will translate old settings into the new format so no behaviour change is expected.
As drive-by I also bumped appVersion