### PR TITLE
core: support EXPERIMENTAL_PARALLEL_TX_SET_DOWNLOAD config

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: core
 description: This chart will deploy Stellar Core node
-version: 0.11.0
+version: 0.12.0
 appVersion: "26.0.1-3109.e78c97ed0.jammy"
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/core/templates/core-cm.yaml
+++ b/charts/core/templates/core-cm.yaml
@@ -139,6 +139,9 @@ data:
     {{ if (.Values.core.config).nodeHomeDomain -}}
     NODE_HOME_DOMAIN={{ .Values.core.config.nodeHomeDomain | quote }}
     {{ end -}}
+    {{ if (.Values.core.config).experimentalParallelTxSetDownload -}}
+    EXPERIMENTAL_PARALLEL_TX_SET_DOWNLOAD={{ .Values.core.config.experimentalParallelTxSetDownload }}
+    {{ end -}}
 
     {{ if (.Values.core.config).historyArchives -}}
     {{ range $key, $value := .Values.core.config.historyArchives -}}


### PR DESCRIPTION
## What

Adds support for the `EXPERIMENTAL_PARALLEL_TX_SET_DOWNLOAD` stellar-core setting to the `core` chart, exposed as `core.config.experimentalParallelTxSetDownload`.

Renders `EXPERIMENTAL_PARALLEL_TX_SET_DOWNLOAD=<value>` into `stellar-core.cfg` when set, and is omitted entirely when unset (same conditional pattern as the other `core.config.*` keys). Booleans render unquoted (`true`/`false`), matching `nodeIsValidator` / `unsafeQuorum`.

## Why

The chart only renders an allowlist of known config keys — there's no pass-through for arbitrary settings, so this experimental flag currently can't be set via `core.config` at all. We want to enable it on futurenet.

## Usage

```yaml
core:
  config:
    experimentalParallelTxSetDownload: true
```

## Notes

- `charts/core/Chart.yaml` version bumped `0.11.0` → `0.12.0` (new feature, minor bump — consistent with prior feature PRs).
- Verified with `helm template`: key renders when set, absent when unset.