### PR TITLE
Add GatewayAPI support to the RPC chart

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.5.0
-appVersion: "26.0.0"
+version: 0.6.0
+appVersion: "27.0.0"
 description: Stellar RPC Helm Chart. This chart will deploy Stellar RPC server
 maintainers:
   - name: Stellar Development Foundation

--- a/charts/soroban-rpc/templates/soroban-rpc-gateway.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-gateway.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.sorobanRpc.httpRoute.enabled .Values.sorobanRpc.httpRoute.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.sorobanRpc.httpRoute.gateway.name | default (printf "%s-gateway" (include "common.fullname" .)) }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- if .Values.sorobanRpc.httpRoute.gateway.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.sorobanRpc.httpRoute.gateway.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.sorobanRpc.httpRoute.gateway.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  gatewayClassName: {{ required "sorobanRpc.httpRoute.gateway.gatewayClassName is required when gateway is enabled" .Values.sorobanRpc.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.sorobanRpc.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-httproute.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-httproute.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.sorobanRpc.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "common.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- if .Values.sorobanRpc.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.sorobanRpc.httpRoute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.sorobanRpc.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.sorobanRpc.httpRoute.gateway.enabled }}
+    - name: {{ .Values.sorobanRpc.httpRoute.gateway.name | default (printf "%s-gateway" (include "common.fullname" .)) }}
+    {{- else }}
+    {{- range .Values.sorobanRpc.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.sorobanRpc.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.sorobanRpc.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ template "common.fullname" . }}
+          port: 8000
+{{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-ingress.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-ingress.yaml
@@ -1,24 +1,4 @@
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "common.fullname" . }}
-  {{- if .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
-  labels:
-    app: {{ template "common.fullname" . }}
-    chart: {{ template "common.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  type: ClusterIP
-  ports:
-    - name: soroban-rpc
-      port: 8000
-      targetPort: 8000
-  selector:
-    app: {{ template "common.fullname" . }}
+{{- if (.Values.sorobanRpc.ingress).enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -52,3 +32,4 @@ spec:
             name: {{ template "common.fullname" . }}
             port:
               number: 8000
+{{- end }}

--- a/charts/soroban-rpc/templates/soroban-rpc-svc.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-svc.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: soroban-rpc
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: {{ template "common.fullname" . }}

--- a/charts/soroban-rpc/values.yaml
+++ b/charts/soroban-rpc/values.yaml
@@ -74,6 +74,10 @@ sorobanRpc:
         history: "curl -sf http://history.stellar.org/dev/core-futurenet/core_futurenet_003/{0} -o {1}"
 
   ingress:
+    ## Whether to render a k8s Ingress. Set to false when exposing soroban-rpc
+    ## via Gateway API HTTPRoute instead (see sorobanRpc.httpRoute).
+    enabled: true
+
     host: example.com
 
     ## Optional TLS secret to use. If not set ingress will default to $releasename-cert
@@ -85,6 +89,45 @@ sorobanRpc:
     ## Additional annotations to add the Ingress template
     #annotations:
     #  cert-manager.io/cluster-issuer: "default"
+
+  ## Controls whether soroban-rpc is exposed via Gateway API HTTPRoute
+  httpRoute:
+    enabled: false
+    ## Reference to an existing external Gateway. Only used when gateway.enabled=false.
+    ## When gateway.enabled=true, parentRefs are auto-computed from the created Gateway.
+    parentRefs:
+      - name: soroban-rpc-gateway
+        namespace: ""  # defaults to release namespace
+        sectionName: ""
+    hostnames:
+      - soroban-rpc.example.com
+    ## Extra annotations to add to the HTTPRoute object
+    annotations: {}
+    ## Extra labels to add to the HTTPRoute object
+    labels: {}
+    ## Optional Gateway resource created in the same namespace
+    gateway:
+      enabled: false
+      ## Gateway class name (e.g. "istio", "traefik")
+      gatewayClassName: ""
+      ## Gateway name override. Defaults to <fullname>-gateway
+      name: ""
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+        # - name: https
+        #   protocol: HTTPS
+        #   port: 443
+        #   hostname: soroban-rpc.example.com
+        #   tls:
+        #     mode: Terminate
+        #     certificateRefs:
+        #       - name: soroban-rpc-tls-cert
+      ## Extra annotations to add to the Gateway object
+      annotations: {}
+      ## Extra labels to add to the Gateway object
+      labels: {}
 
   ## Whether to provision persistent volume(PV). Recommended for production use cases and any deployment that is
   ## configured to be on the pubnet network. On pubnet network, disk requirements start at 30GB minimum,


### PR DESCRIPTION
This PR adds Gateway API support to the RPC chart. The support is backwards compabitle as default behaviour does not change.
As drive-by I also bumped appVersion