### PR TITLE
horizon: improve cnpg credential handling

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: horizon
-version: 0.7.1
+version: 0.8.1
 appVersion: "27.0.0"
 description: Stellar Horizon Helm Chart. This chart will deploy Stellar Horizon API server
 maintainers: 

--- a/charts/horizon/README.md
+++ b/charts/horizon/README.md
@@ -22,9 +22,22 @@ helm install myhorizon stellar/horizon \
   --set cnpg.auth.password=change-me
 ```
 
+Example using an existing CNPG bootstrap secret:
+```
+helm install myhorizon stellar/horizon \
+  --set cnpg.enabled=true \
+  --set cnpg.cluster.spec.bootstrap.initdb.database=horizon \
+  --set cnpg.cluster.spec.bootstrap.initdb.owner=horizon \
+  --set cnpg.cluster.spec.bootstrap.initdb.secret.name=cnpg-db-creds \
+  --set ingest.existingSecret=horizon-db-url
+```
+
 Notes:
 - CloudNativePG operator and CRDs must already be installed in the cluster.
-- `cnpg.auth.password` is required whenever `cnpg.enabled=true` (it is used to bootstrap the CNPG cluster user and to generate the `DATABASE_URL` secret when `ingest.existingSecret` / `web.existingSecret` are not set).
+- `cnpg.auth.password` is required only when this chart manages CNPG bootstrap credentials and/or generates the `DATABASE_URL` secret.
+- `cnpg.auth.username` and `cnpg.auth.password` are mutually exclusive with `cnpg.cluster.spec.bootstrap.initdb.secret.name`.
+- If you provide `cnpg.cluster.spec.bootstrap` (for example `bootstrap.initdb.secret.name`), chart-managed CNPG bootstrap credentials are skipped.
+- Auto-generated `DATABASE_URL` still requires `cnpg.auth.password`; if it is not set, provide `ingest.existingSecret` and/or `web.existingSecret`.
 - You can still use external DB credentials by setting `ingest.existingSecret` and/or `web.existingSecret`.
 - Any field on the CNPG `Cluster.spec` (instances, storage, `enablePDB`, monitoring, backup, etc.) can be set under `cnpg.cluster.spec`. See `values.yaml` for details.
 

--- a/charts/horizon/templates/_cnpg.tpl
+++ b/charts/horizon/templates/_cnpg.tpl
@@ -16,9 +16,8 @@
          - storage.storageClass
     3. .Values.cnpg.cluster.spec (wins on conflict).
 
-  `bootstrap` is always injected from .Values.cnpg.auth and the chart-
-  managed app secret; it can still be overridden via
-  .Values.cnpg.cluster.spec.bootstrap.
+  `bootstrap` is injected from .Values.cnpg.auth and the chart-managed app
+  secret only when .Values.cnpg.cluster.spec.bootstrap is not provided.
 
   Returns the spec as YAML (without indentation); callers should pipe it
   through `nindent` at the desired indent level.
@@ -28,6 +27,7 @@
       {{- include "horizon.cnpgClusterSpec" . | nindent 2 }}
 */}}
 {{- define "horizon.cnpgClusterSpec" -}}
+{{- $extra := default (dict) .Values.cnpg.cluster.spec -}}
 {{- /* Built-in defaults (lowest priority; overridable by legacy shortcuts or by cnpg.cluster.spec) */ -}}
 {{- $shortcuts := dict
     "instances" 1
@@ -47,12 +47,13 @@
 {{- if $legacyStorage.storageClass -}}
   {{- $_ := set (index $shortcuts "storage") "storageClass" $legacyStorage.storageClass -}}
 {{- end -}}
-{{- /* Always-injected bootstrap (still overridable via cnpg.cluster.spec.bootstrap) */ -}}
-{{- $_ := set $shortcuts "bootstrap" (dict "initdb" (dict
-    "database" (required "cnpg.auth.database is required when cnpg.enabled=true" .Values.cnpg.auth.database)
-    "owner"    (required "cnpg.auth.username is required when cnpg.enabled=true" .Values.cnpg.auth.username)
-    "secret"   (dict "name" (include "horizon.cnpgAppSecretName" .)))) -}}
-{{- $extra := default (dict) .Values.cnpg.cluster.spec -}}
+{{- /* Inject bootstrap defaults only when caller did not provide cluster.spec.bootstrap */ -}}
+{{- if not (hasKey $extra "bootstrap") -}}
+  {{- $_ := set $shortcuts "bootstrap" (dict "initdb" (dict
+      "database" (required "cnpg.auth.database is required when cnpg.enabled=true" .Values.cnpg.auth.database)
+  "owner"    (default "horizon" .Values.cnpg.auth.username)
+      "secret"   (dict "name" (include "horizon.cnpgAppSecretName" .)))) -}}
+{{- end -}}
 {{- $spec := mergeOverwrite $shortcuts (deepCopy $extra) -}}
 {{- toYaml $spec }}
 {{- end -}}

--- a/charts/horizon/templates/_helpers.tpl
+++ b/charts/horizon/templates/_helpers.tpl
@@ -67,7 +67,11 @@ Public Global Stellar Network ; September 2015
 {{- if .Values.ingest.existingSecret -}}
 {{- .Values.ingest.existingSecret -}}
 {{- else if .Values.cnpg.enabled -}}
+{{- if .Values.cnpg.auth.password -}}
 {{- include "horizon.defaultDatabaseSecretName" . -}}
+{{- else -}}
+{{- required "Set ingest.existingSecret when cnpg.auth.password is empty (for example when using cnpg.cluster.spec.bootstrap.initdb.secret.name)" .Values.ingest.existingSecret -}}
+{{- end -}}
 {{- else -}}
 {{- required "Set ingest.existingSecret or enable cnpg.enabled" .Values.ingest.existingSecret -}}
 {{- end -}}
@@ -77,7 +81,11 @@ Public Global Stellar Network ; September 2015
 {{- if .Values.web.existingSecret -}}
 {{- .Values.web.existingSecret -}}
 {{- else if .Values.cnpg.enabled -}}
+{{- if .Values.cnpg.auth.password -}}
 {{- include "horizon.defaultDatabaseSecretName" . -}}
+{{- else -}}
+{{- required "Set web.existingSecret when cnpg.auth.password is empty (for example when using cnpg.cluster.spec.bootstrap.initdb.secret.name)" .Values.web.existingSecret -}}
+{{- end -}}
 {{- else -}}
 {{- required "Set web.existingSecret or enable cnpg.enabled" .Values.web.existingSecret -}}
 {{- end -}}
@@ -99,8 +107,21 @@ Public Global Stellar Network ; September 2015
 {{- printf "%s-app" (include "horizon.cnpgClusterName" .) -}}
 {{- end -}}
 
+{{- define "horizon.validateCnpgAuthBootstrapConfig" -}}
+{{- if .Values.cnpg.enabled -}}
+{{- $clusterSpec := default (dict) .Values.cnpg.cluster.spec -}}
+{{- $bootstrap := default (dict) (get $clusterSpec "bootstrap") -}}
+{{- $initdb := default (dict) (get $bootstrap "initdb") -}}
+{{- $secret := default (dict) (get $initdb "secret") -}}
+{{- $bootstrapSecretName := default "" (get $secret "name") -}}
+{{- if and $bootstrapSecretName (or .Values.cnpg.auth.username .Values.cnpg.auth.password) -}}
+{{- fail "cnpg.auth.username and cnpg.auth.password are mutually exclusive with cnpg.cluster.spec.bootstrap.initdb.secret.name" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "horizon.databaseUrl" -}}
-{{- $user := required "cnpg.auth.username is required when cnpg.enabled=true" .Values.cnpg.auth.username -}}
+{{- $user := default "horizon" .Values.cnpg.auth.username -}}
 {{- $password := required "cnpg.auth.password is required when cnpg.enabled=true and auto-generated DATABASE_URL is used" .Values.cnpg.auth.password -}}
 {{- $database := required "cnpg.auth.database is required when cnpg.enabled=true" .Values.cnpg.auth.database -}}
 {{- printf "postgres://%s:%s@%s:5432/%s?sslmode=disable" $user ($password | urlquery) (include "horizon.cnpgReadWriteHost" .) $database -}}

--- a/charts/horizon/templates/cnpg-app-secret.yaml
+++ b/charts/horizon/templates/cnpg-app-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.cnpg.enabled }}
+{{- $clusterSpec := default (dict) .Values.cnpg.cluster.spec -}}
+{{- if and .Values.cnpg.enabled (not (hasKey $clusterSpec "bootstrap")) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
-  username: {{ required "cnpg.auth.username is required when cnpg.enabled=true" .Values.cnpg.auth.username | quote }}
+  username: {{ default "horizon" .Values.cnpg.auth.username | quote }}
   password: {{ required "cnpg.auth.password is required when cnpg.enabled=true" .Values.cnpg.auth.password | quote }}
 {{- end }}

--- a/charts/horizon/templates/cnpg-cluster.yaml
+++ b/charts/horizon/templates/cnpg-cluster.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cnpg.enabled }}
+{{- include "horizon.validateCnpgAuthBootstrapConfig" . }}
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster

--- a/charts/horizon/templates/database-secret.yaml
+++ b/charts/horizon/templates/database-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cnpg.enabled (or (and .Values.ingest.enabled (not .Values.ingest.existingSecret)) (and .Values.web.enabled (not .Values.web.existingSecret))) }}
+{{- if and .Values.cnpg.enabled .Values.cnpg.auth.password (or (and .Values.ingest.enabled (not .Values.ingest.existingSecret)) (and .Values.web.enabled (not .Values.web.existingSecret))) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -59,7 +59,14 @@ global:
 cnpg:
   enabled: false
   auth:
-    username: horizon
+    ## Optional. Defaults to "horizon" for chart-managed credentials.
+    ## Must be empty when cnpg.cluster.spec.bootstrap.initdb.secret.name is set.
+    username: ""
+    ## Required when the chart should auto-manage CNPG bootstrap credentials
+    ## and/or auto-generate DATABASE_URL.
+    ## Optional when you provide cnpg.cluster.spec.bootstrap (for example
+    ## bootstrap.initdb.secret.name) and set ingest.existingSecret / web.existingSecret.
+    ## Must be empty when cnpg.cluster.spec.bootstrap.initdb.secret.name is set.
     password: ""
     database: horizon
   cluster:
@@ -87,9 +94,13 @@ cnpg:
     ## Notes:
     ## - Fields are passed through unchanged; validation is done by the CNPG
     ##   webhook, not by this chart.
-    ## - `bootstrap` is auto-populated from `cnpg.auth.*` and the chart-
-    ##   managed app secret. Override it only if you also set
-    ##   ingest.existingSecret / web.existingSecret to bring your own DB URL.
+    ## - If `bootstrap` is omitted, it is auto-populated from `cnpg.auth.*`
+    ##   and the chart-managed app secret.
+    ## - If `bootstrap` is provided (for example with
+    ##   `bootstrap.initdb.secret.name`), chart-managed bootstrap credentials
+    ##   are not rendered.
+    ## - Auto-generated DATABASE_URL requires `cnpg.auth.password`; when it is
+    ##   empty, set `ingest.existingSecret` / `web.existingSecret`.
     ## - Built-in defaults are `instances: 1` and `storage.size: 50Gi`;
     ##   anything set here (or via the legacy `cnpg.cluster.storage.*` /
     ##   `cnpg.cluster.instances` / `cnpg.cluster.imageName` shortcuts)


### PR DESCRIPTION
Currently creds can't be provided via pre-exisitng secret - they have to come from the values file.
This PR makes it possible to provide existing secret via the following:
```
cnpg:
  cluster:
    spec:
      bootstrap:
        initdb:
          secret:
            name: cnpg-db-creds
```

Original method is still active so the changes should be backwards compatible