### PR TITLE
Add new config option support to the RPC chart

### DIFF
--- a/charts/soroban-rpc/Chart.yaml
+++ b/charts/soroban-rpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: soroban-rpc
-version: 0.6.0
+version: 0.6.1
 appVersion: "27.0.0"
 description: Stellar RPC Helm Chart. This chart will deploy Stellar RPC server
 maintainers:

--- a/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
+++ b/charts/soroban-rpc/templates/soroban-rpc-cm.yaml
@@ -44,6 +44,9 @@ data:
     {{ if (.Values.sorobanRpc.coreConfig).enableDiagnosticEvents -}}
     ENABLE_SOROBAN_DIAGNOSTIC_EVENTS={{ (.Values.sorobanRpc.coreConfig).enableDiagnosticEvents }}
     {{ end -}}
+    {{ if (.Values.sorobanRpc.coreConfig).enableDiagnosticsForTxSubmission -}}
+    ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION={{ (.Values.sorobanRpc.coreConfig).enableDiagnosticsForTxSubmission }}
+    {{ end -}}
     {{ if (.Values.sorobanRpc.coreConfig).httpMaxClient -}}
     HTTP_MAX_CLIENT={{ .Values.sorobanRpc.coreConfig.httpMaxClient }}
     {{ end -}}


### PR DESCRIPTION
This change adds support for controlling DIAGNOSTICS_FOR_TX_SUBMISSION in the captivecore config.