### PR TITLE
horizon: add persistentVolumeClaimRetentionPolicy support

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: horizon
-version: 0.8.1
+version: 0.9.0
 appVersion: "27.0.0"
 description: Stellar Horizon Helm Chart. This chart will deploy Stellar Horizon API server
 maintainers: 

--- a/charts/horizon/templates/ingest.yaml
+++ b/charts/horizon/templates/ingest.yaml
@@ -19,6 +19,10 @@ spec:
   {{- if not (.Values.useDeployment) }}
   podManagementPolicy: {{ .Values.ingest.podManagementPolicy }}
   serviceName: {{ include "common.fullname" . }}-ingest
+  {{- if and .Values.ingest.persistence.enabled .Values.ingest.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.ingest.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/horizon/values.yaml
+++ b/charts/horizon/values.yaml
@@ -155,6 +155,11 @@ ingest:
     enabled: false
     storageClass: default
     size: 100G
+    ## Persistent volume claim retention policy for the StatefulSet.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Retain
+    #   whenScaled: Retain
 
   resources: {}
   #  limits:


### PR DESCRIPTION
This PR adds support for persistentVolumeClaimRetentionPolicy to match other charts. Default behaviour is the same so the change should be backwards compatible.