### PR TITLE
friendbot: add GatewayAPI support

### DIFF
--- a/charts/friendbot/Chart.yaml
+++ b/charts/friendbot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: friendbot
 description: This chart will deploy friendbot to your private network
-version: 0.0.4
+version: 0.1.0
 appVersion: "bbdf3132"
 maintainers: 
   - name: Stellar Development Foundation

--- a/charts/friendbot/templates/friendbot-gateway.yaml
+++ b/charts/friendbot/templates/friendbot-gateway.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.friendbot.httpRoute.enabled .Values.friendbot.httpRoute.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.friendbot.httpRoute.gateway.name | default (printf "%s-gateway" (include "common.fullname" .)) }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- if .Values.friendbot.httpRoute.gateway.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.friendbot.httpRoute.gateway.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.friendbot.httpRoute.gateway.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  gatewayClassName: {{ required "friendbot.httpRoute.gateway.gatewayClassName is required when gateway is enabled" .Values.friendbot.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.friendbot.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/friendbot/templates/friendbot-gateway.yaml
+++ b/charts/friendbot/templates/friendbot-gateway.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.friendbot.httpRoute.enabled .Values.friendbot.httpRoute.gateway.enabled }}
+{{- if and (dig "httpRoute" "enabled" false .Values.friendbot) (dig "httpRoute" "gateway" "enabled" false .Values.friendbot) }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/charts/friendbot/templates/friendbot-httproute.yaml
+++ b/charts/friendbot/templates/friendbot-httproute.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.friendbot.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "common.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- if .Values.friendbot.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.friendbot.httpRoute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "common.fullname" . }}
+    chart: {{ template "common.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.friendbot.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.friendbot.httpRoute.gateway.enabled }}
+    - name: {{ .Values.friendbot.httpRoute.gateway.name | default (printf "%s-gateway" (include "common.fullname" .)) }}
+    {{- else }}
+    {{- range .Values.friendbot.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.friendbot.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.friendbot.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ template "common.fullname" . }}
+          port: {{ .Values.friendbot.configmap.port | default 8000 }}
+{{- end }}

--- a/charts/friendbot/templates/friendbot-httproute.yaml
+++ b/charts/friendbot/templates/friendbot-httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.friendbot.httpRoute.enabled }}
+{{- if dig "httpRoute" "enabled" false .Values.friendbot }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/friendbot/templates/friendbot-ingress.yaml
+++ b/charts/friendbot/templates/friendbot-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.friendbot.ingress).enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -31,3 +32,4 @@ spec:
             name: {{ template "common.fullname" . }}
             port:
               number: {{ .Values.friendbot.configmap.port | default 8000 }}
+{{- end }}

--- a/charts/friendbot/templates/friendbot-ingress.yaml
+++ b/charts/friendbot/templates/friendbot-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.friendbot.ingress).enabled }}
+{{- if dig "ingress" "enabled" true .Values.friendbot }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/friendbot/values.yaml
+++ b/charts/friendbot/values.yaml
@@ -49,10 +49,53 @@ friendbot:
     #   mylabel1: "myvalue1"
 
   ingress:
+    ## Whether to render a k8s Ingress. Set to false when exposing friendbot
+    ## via Gateway API HTTPRoute instead (see friendbot.httpRoute).
+    enabled: true
+
     host: "friendbot.example.com"
     # ingressClassName: ""
     # annotations:
     #   cert-manager.io/cluster-issuer: "default"
+
+  ## Controls whether friendbot is exposed via Gateway API HTTPRoute
+  httpRoute:
+    enabled: false
+    ## Reference to an existing external Gateway. Only used when gateway.enabled=false.
+    ## When gateway.enabled=true, parentRefs are auto-computed from the created Gateway.
+    parentRefs:
+      - name: friendbot-gateway
+        namespace: ""  # defaults to release namespace
+        sectionName: ""
+    hostnames:
+      - friendbot.example.com
+    ## Extra annotations to add to the HTTPRoute object
+    annotations: {}
+    ## Extra labels to add to the HTTPRoute object
+    labels: {}
+    ## Optional Gateway resource created in the same namespace
+    gateway:
+      enabled: false
+      ## Gateway class name (e.g. "istio", "traefik")
+      gatewayClassName: ""
+      ## Gateway name override. Defaults to <fullname>-gateway
+      name: ""
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+        # - name: https
+        #   protocol: HTTPS
+        #   port: 443
+        #   hostname: friendbot.example.com
+        #   tls:
+        #     mode: Terminate
+        #     certificateRefs:
+        #       - name: friendbot-tls-cert
+      ## Extra annotations to add to the Gateway object
+      annotations: {}
+      ## Extra labels to add to the Gateway object
+      labels: {}
 
   secret:
     ## Friendbot requires account seed to be configured. This can be provided using two mutually exclusive ways:


### PR DESCRIPTION
This PR adds GatewayAPI support in a way that matches other charts.
Default behaviour stays the same so the change is
backwards compatible.